### PR TITLE
reset of hash contexts and keccak finalization to ptr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,19 +11,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.7', '9.0.1', '9.2']
-        cabal: ['3.6']
+        ghc: ['8.10.7', '9.0.2', '9.2']
+        cabal: ['3.8']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
         cryptonite: ['-test-cryptonite -benchmark-cryptonite', '+test-cryptonite +benchmark-cryptonite']
         openssl: [ '+with-openssl', '-with-openssl' ]
         include:
-        - ghc: '9.0.1'
-          cabal: '3.6'
+        - ghc: '9.0.2'
+          cabal: '3.8'
           os: 'macOS-latest'
           cryptonite: '+test-cryptonite +benchmark-cryptonite'
           openssl: '+with-openssl'
         - ghc: '8.10.7'
-          cabal: '3.6'
+          cabal: '3.8'
           os: 'macOS-latest'
           cryptonite: '+test-cryptonite +benchmark-cryptonite'
           openssl: '+with-openssl'
@@ -32,15 +32,15 @@ jobs:
 
     # Setup
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install GHC and Cabal
-      uses: haskell/actions/setup@v2
+      uses: haskell/actions/setup@v2.0.2
       with:
          ghc-version: ${{ matrix.ghc }}
          cabal-version: ${{ matrix.cabal }}
 
     # Restore Packages from Caches
-    - uses: pat-s/always-upload-cache@v2.1.5
+    - uses: actions/cache@v3
       name: Cache dist-newstyle
       with:
         path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for the hashes package
 
+## 0.2.3 -- 2022-11-22
+
+*   Support reset and reuse of context for OpenSSL digests.
+*   Avoid the use of deprecated OpenSSL methods.
+*   Add methods to write digests directly to a pointer for Keccak digests.
+
 ## 0.2.2.1 -- 2022-09-28
 
 *   Support for Apple Silicon (`aarch64_HOST_ARCH`)

--- a/cbits/keccak.c
+++ b/cbits/keccak.c
@@ -34,7 +34,7 @@ finally:
 /* *************************************************************************** */
 /* OpenSSL 1.1 and OpenSSL 3.0 */
 
-/* The computation of the magic offset is base on the keccak_st structure in
+/* The computation of the magic offset is based on the keccak_st structure in
  * OpenSSL-1.1 and OpenSSL-3.0
  *
  * Assuming conventional alignment, the bytes offset is
@@ -79,7 +79,7 @@ finally:
 
 /* OPENSSL 3.1 */
 #if OPENSSL_VERSION_NUMBER >= 0x31000000L
-#define SET_PAD_BYTE 
+#define SET_PAD_BYTE
 
 /* OPENSSL 3.0 */
 #elif OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -111,7 +111,7 @@ int keccak256_init(KECCAK256_CTX *ctx) {
     int ok = 1;
     const EVP_MD *md = NULL;
     CHECKED(md = EVP_get_digestbyname("SHA3-256"));
-    CHECKED(EVP_DigestInit(ctx, md));
+    CHECKED(EVP_DigestInit_ex(ctx, md, NULL));
     SET_PAD_BYTE;
 finally:
     return ok;
@@ -121,7 +121,23 @@ int keccak512_init(KECCAK512_CTX *ctx) {
     int ok = 1;
     const EVP_MD *md = NULL;
     CHECKED(md = EVP_get_digestbyname("SHA3-512"));
-    CHECKED(EVP_DigestInit(ctx, md));
+    CHECKED(EVP_DigestInit_ex(ctx, md, NULL));
+    SET_PAD_BYTE;
+finally:
+    return ok;
+}
+
+int keccak256_reset(KECCAK512_CTX *ctx) {
+    int ok = 1;
+    CHECKED(EVP_DigestInit_ex(ctx, NULL, NULL));
+    SET_PAD_BYTE;
+finally:
+    return ok;
+}
+
+int keccak512_reset(KECCAK512_CTX *ctx) {
+    int ok = 1;
+    CHECKED(EVP_DigestInit_ex(ctx, NULL, NULL));
     SET_PAD_BYTE;
 finally:
     return ok;
@@ -140,13 +156,13 @@ int keccak512_update(KECCAK512_CTX *ctx, const void *p, size_t l)
 int keccak256_final(KECCAK256_CTX *ctx, unsigned char *md)
 {
     unsigned int l;
-    return EVP_DigestFinal(ctx, md, &l);
+    return EVP_DigestFinal_ex(ctx, md, &l);
 }
 
 int keccak512_final(KECCAK512_CTX *ctx, unsigned char *md)
 {
     unsigned int l;
-    return EVP_DigestFinal(ctx, md, &l);
+    return EVP_DigestFinal_ex(ctx, md, &l);
 }
 
 void keccak256_freectx(KECCAK256_CTX *ctx)

--- a/cbits/keccak.h
+++ b/cbits/keccak.h
@@ -17,6 +17,7 @@ typedef EVP_MD_CTX KECCAK512_CTX;
 // KECCAK-256
 KECCAK256_CTX *keccak256_newctx();
 int keccak256_init(KECCAK256_CTX *ctx);
+int keccak256_reset(KECCAK256_CTX *ctx);
 int keccak256_update(KECCAK256_CTX *ctx, const void *p, size_t l);
 int keccak256_final(KECCAK256_CTX *ctx, unsigned char *md);
 void keccak256_freectx(KECCAK256_CTX *ctx);
@@ -24,6 +25,7 @@ void keccak256_freectx(KECCAK256_CTX *ctx);
 // KECCAK-512
 KECCAK512_CTX *keccak512_newctx();
 int keccak512_init(KECCAK512_CTX *ctx);
+int keccak512_reset(KECCAK512_CTX *ctx);
 int keccak512_update(KECCAK512_CTX *ctx, const void *p, size_t l);
 int keccak512_final(KECCAK512_CTX *ctx, unsigned char *md);
 void keccak512_freectx(KECCAK512_CTX *ctx);

--- a/hashes.cabal
+++ b/hashes.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name: hashes
-version: 0.2.2.1
+version: 0.2.3
 synopsis: Hash functions
 Description: Efficient implementations of hash functions
 homepage: https://github.com/larskuhtz/hs-hashes

--- a/src/Data/Hash/Class/Mutable.hs
+++ b/src/Data/Hash/Class/Mutable.hs
@@ -29,6 +29,9 @@ module Data.Hash.Class.Mutable
 , updateShortByteString
 , updateStorable
 , updateByteArray
+
+-- * Resetable Hashes
+, ResetableHash(..)
 ) where
 
 import qualified Data.ByteString as B
@@ -47,7 +50,7 @@ import GHC.IO
 import Data.Hash.Class.Mutable.Internal
 
 -- -------------------------------------------------------------------------- --
--- Class of Salted Pure Hashes
+-- Class of Mutable Hashes
 
 class IncrementalHash a => Hash a where
     initialize :: IO (Context a)

--- a/src/Data/Hash/Class/Mutable/Internal.hs
+++ b/src/Data/Hash/Class/Mutable/Internal.hs
@@ -12,15 +12,20 @@
 -- Maintainer: Lars Kuhtz <lakuhtz@gmail.com>
 -- Stability: experimental
 --
--- Incremental Mutable Hashes
+-- Incremental and Resetable Mutable Hashes
 --
 module Data.Hash.Class.Mutable.Internal
-( IncrementalHash(..)
+(
+-- * Incremental Hashes
+  IncrementalHash(..)
 , updateByteString
 , updateByteStringLazy
 , updateShortByteString
 , updateStorable
 , updateByteArray
+
+-- * Resetable Hashes
+, ResetableHash(..)
 ) where
 
 import qualified Data.ByteString as B
@@ -103,4 +108,10 @@ updateByteArray ctx a# = case isByteArrayPinned# a# of
   where
     size# = sizeofByteArray# a#
 {-# INLINE updateByteArray #-}
+
+-- -------------------------------------------------------------------------- --
+-- Class of Resetable Hashes
+
+class IncrementalHash a => ResetableHash a where
+    reset :: Context a -> IO ()
 

--- a/src/Data/Hash/Keccak.hs
+++ b/src/Data/Hash/Keccak.hs
@@ -33,6 +33,11 @@ module Data.Hash.Keccak
   Keccak256(..)
 , Keccak512(..)
 , module Data.Hash.Class.Mutable
+
+-- *** Unsafe finalize functions
+, finalizeKeccak256Ptr
+, finalizeKeccak512Ptr
+
 ) where
 
 import Data.Hash.Class.Mutable


### PR DESCRIPTION
* support reset of hash contexts
* finalization to a ptr for Keccak256 and Keccak512
* Remove use of deprecated OpenSSL functions