### PR TITLE
0.4.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         ghc:
-        - '9.2'
-        - '9.4'
         - '9.6'
         - '9.10'
+        - '9.12'
         cabal:
         - '3.12'
         os:
@@ -29,15 +28,15 @@ jobs:
         - '-with-openssl'
         include:
         - ghc: '9.2'
-          os: macos-latest
+          os: ubuntu-22.04
           cabal: '3.12'
           cryptonite: '+test-cryptonite +benchmark-cryptonite'
           openssl: '+with-openssl'
         - ghc: '9.4'
-          os: macos-latest
+          os: ubuntu-22.04
           cabal: '3.12'
-          cryptonite: '-test-cryptonite +benchmark-cryptonite'
-          openssl: '-with-openssl'
+          cryptonite: '+test-cryptonite +benchmark-cryptonite'
+          openssl: '+with-openssl'
         - ghc: '9.6'
           os: macos-latest
           cabal: '3.12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Revision history for the hashes package
 
+## 0.4.0.0 -- 2025-03-05
+
+Breaking Changes:
+
+`Data.Hash.Class.Mutable`:
+*   In class `IncrementalHash`
+    *   add `DigestSize` type family,
+    *   rename class method `update` into `updatePtr`,
+    *   add class method `update#`,
+    *   add new class methods `finalize#`, `finalizePtr`, and
+    *   provide reasonable default implementations for all class methods.
+*   In signatures of `hashByteArray` and `hashByteArray_` replace primitive
+    `ByteArray#` by lifted `ByteArray`.
+*   In signature of `updateByteArray` replace primitive `ByteArray#` by
+    lifted `ByteArray`.
+
+`Data.Hash.Class.Pure`:
+*   In class `IncrementalHash`
+    *   add `DigestSize` type family,
+    *   rename class method `update` into `updatePtr`,
+    *   add class method `update#`,
+    *   provide reasonable default implementations for all class methods.
+*   In signature of `hashByteArray` replace primitive `ByteArray#` by lifted
+    `ByteArray`.
+*   In signature of `updateByteArray` replace primitive `ByteArray#` by
+    lifted `ByteArray`.
+
+`Data.Hash.Class.Mutable.Salted`:
+*   In signatures of `hashByteArray` and `hashByteArray_` replace primitive
+    `ByteArray#` by lifted `ByteArray`.
+*   In signature of `updateByteArray` replace primitive `ByteArray#` by
+    lifted `ByteArray`.
+
+`Data.Hash.Class.Pure.Salted`:
+*   In signature of `hashByteArray` replace primitive `ByteArray#` by lifted
+    `ByteArray`.
+*   In signature of `updateByteArray` replace primitive `ByteArray#` by
+    lifted `ByteArray`.
+
+`Data.Hash.Keccak`:
+*   remove functions `finalizeKeccak256Ptr` and `finalizeKeccakt512Ptr`.
+
+Other Changes:
+
+*   Add new function `digestSize` to `Data.Hash.Class.Mutable` and
+    `Data.Hash.Class.Mutable.Salted`.
+*   Add new functions `hashByteArray#` and `hashByteArray_#` that take a
+    primitive `ByteArray#` to `Data.Hash.Class.Mutable` and
+    `Data.Hash.Class.Mutable.Salted`.
+*   Add new function `hashByteArray#` that takes a primitive `ByteArray#` to
+    `Data.Hash.Class.Pure` and `Data.Hash.Class.Pure.Salted`.
+*   Export `OpenSslException` from modules `Data.Hash.Blake2`,
+    `Data.Hash.Keccak`, `Data.Hash.SHA2`, and `Data.Hash.SHA3`.
+
 ## 0.3.0.1 -- 2024-08-20
 
 *   Fix building the package on Gentoo.

--- a/cbits/evp_wrapper.h
+++ b/cbits/evp_wrapper.h
@@ -1,0 +1,19 @@
+#ifndef EVP_WRAPPER_H
+#define EVP_WRAPPER_H
+
+#include <stddef.h>
+
+int EVP_DigestUpdate(void*, const void*, size_t);
+int EVP_DigestFinal_ex(void*, unsigned char*, unsigned int*);
+int EVP_DigestFinalXOF(void*, unsigned char*, size_t);
+
+#define EVP_DigestUpdate_off(ctx, data, off, count) \
+    EVP_DigestUpdate((ctx), ((data) + (off)), (count))
+
+#define EVP_DigestFinal_ex_off(ctx, data, off, sptr) \
+    EVP_DigestFinal_ex((ctx), ((data) + (off)), (sptr))
+
+#define EVP_DigestFinalXOF_off(ctx, data, off, count) \
+    EVP_DigestFinalXOF((ctx), ((data) + (off)), (count))
+
+#endif // EVP_WRAPPER_H

--- a/hashes.cabal
+++ b/hashes.cabal
@@ -12,6 +12,7 @@ maintainer: lakuhtz@gmail.com
 copyright: Copyright (c) 2019-2024 Lars Kuhtz <lakuhtz@gmail.com>
 category: Data
 tested-with:
+    GHC==9.12
     GHC==9.10
     GHC==9.6
     GHC==9.4

--- a/hashes.cabal
+++ b/hashes.cabal
@@ -23,6 +23,7 @@ extra-doc-files:
 extra-source-files:
     cbits/keccak.h
     cbits/keccak.c
+    cbits/evp_wrapper.h
 
 source-repository head
     type: git
@@ -55,13 +56,13 @@ common openssl-common
         c-sources:
             cbits/keccak.c
         includes:
-            cbits/evp_wrapper.h
+            evp_wrapper.h
+        include-dirs: cbits
         cpp-options: -DWITH_OPENSSL=1
         if flag(openssl-use-pkg-config)
             pkgconfig-depends: libcrypto
         else
             extra-libraries: crypto
-        include-dirs: cbits
 
 library
     import: openssl-common

--- a/hashes.cabal
+++ b/hashes.cabal
@@ -53,6 +53,8 @@ common openssl-common
     if flag(with-openssl)
         c-sources:
             cbits/keccak.c
+        includes:
+            cbits/evp_wrapper.h
         cpp-options: -DWITH_OPENSSL=1
         if flag(openssl-use-pkg-config)
             pkgconfig-depends: libcrypto
@@ -93,7 +95,10 @@ library
         -msse4.2
     build-depends:
         , base >=4.11 && <5
-        , bytestring >=0.10
+        , bytestring >=0.12
+    if impl(ghc < 9.4)
+        build-depends: data-array-byte
+            , data-array-byte >=0.1
 
 test-suite tests
     import: openssl-common

--- a/hashes.cabal
+++ b/hashes.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: hashes
-version: 0.3.0.1
+version: 0.4.0.0
 synopsis: Hash functions
 Description: Efficient implementations of hash functions
 homepage: https://github.com/larskuhtz/hs-hashes
@@ -9,7 +9,7 @@ license: MIT
 license-file: LICENSE
 author: Lars Kuhtz
 maintainer: lakuhtz@gmail.com
-copyright: Copyright (c) 2019-2024 Lars Kuhtz <lakuhtz@gmail.com>
+copyright: Copyright (c) 2019-2025 Lars Kuhtz <lakuhtz@gmail.com>
 category: Data
 tested-with:
     GHC==9.12

--- a/src/Data/Hash/Blake2.hs
+++ b/src/Data/Hash/Blake2.hs
@@ -23,9 +23,9 @@ module Data.Hash.Blake2
 , Blake2s256(..)
 
 , module Data.Hash.Class.Mutable
+, OpenSslException(..)
 ) where
 
 import Data.Hash.Class.Mutable
 import Data.Hash.Internal.OpenSSL
-
 

--- a/src/Data/Hash/Class/Mutable.hs
+++ b/src/Data/Hash/Class/Mutable.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Mutable
@@ -23,6 +24,7 @@ module Data.Hash.Class.Mutable
 , hashByteStringLazy
 , hashShortByteString
 , hashByteArray
+, hashByteArray#
 
 -- ** Pure variants of hash functions
 --
@@ -39,6 +41,7 @@ module Data.Hash.Class.Mutable
 , hashByteStringLazy_
 , hashShortByteString_
 , hashByteArray_
+, hashByteArray_#
 
 -- * Incremental Hashing
 , updateByteString
@@ -51,9 +54,10 @@ module Data.Hash.Class.Mutable
 , ResetableHash(..)
 ) where
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
 import Data.Word
 
 import Foreign.Ptr
@@ -79,7 +83,7 @@ class IncrementalHash a => Hash a where
 hashPtr :: forall a . Hash a => Ptr Word8 -> Int -> IO a
 hashPtr p n = do
     ctx <- initialize @a
-    update @a ctx p n
+    updatePtr @a ctx p n
     finalize ctx
 {-# INLINE hashPtr #-}
 
@@ -111,12 +115,19 @@ hashStorable b = do
     finalize ctx
 {-# INLINE hashStorable #-}
 
-hashByteArray :: forall a . Hash a => ByteArray# -> IO a
+hashByteArray :: forall a . Hash a => ByteArray -> IO a
 hashByteArray b = do
     ctx <- initialize @a
     updateByteArray @a ctx b
     finalize ctx
 {-# INLINE hashByteArray #-}
+
+hashByteArray# :: forall a . Hash a => ByteArray# -> IO a
+hashByteArray# b = do
+    ctx <- initialize @a
+    update# @a ctx b
+    finalize ctx
+{-# INLINE hashByteArray# #-}
 
 -- --------------------------------------------------------------------------
 -- Pure variants of hashes
@@ -141,7 +152,11 @@ hashStorable_ :: forall a b . Hash a => Storable b => b -> a
 hashStorable_ = unsafePerformIO . hashStorable
 {-# INLINE hashStorable_ #-}
 
-hashByteArray_ :: forall a . Hash a => ByteArray# -> a
+hashByteArray_ :: forall a . Hash a => ByteArray -> a
 hashByteArray_ a = unsafePerformIO $ hashByteArray a
 {-# INLINE hashByteArray_ #-}
+
+hashByteArray_# :: forall a . Hash a => ByteArray# -> a
+hashByteArray_# a = unsafePerformIO $ hashByteArray# a
+{-# INLINE hashByteArray_# #-}
 

--- a/src/Data/Hash/Class/Mutable.hs
+++ b/src/Data/Hash/Class/Mutable.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Mutable
@@ -16,6 +17,7 @@
 module Data.Hash.Class.Mutable
 ( Hash(..)
 , IncrementalHash(..)
+, digestSize
 
 -- * Hash functions
 , hashPtr

--- a/src/Data/Hash/Class/Mutable.hs
+++ b/src/Data/Hash/Class/Mutable.hs
@@ -125,9 +125,9 @@ hashByteArray b = do
 {-# INLINE hashByteArray #-}
 
 hashByteArray# :: forall a . Hash a => ByteArray# -> IO a
-hashByteArray# b = do
+hashByteArray# b# = do
     ctx <- initialize @a
-    update# @a ctx b
+    update# @a ctx b# 0# (sizeofByteArray# b#)
     finalize ctx
 {-# INLINE hashByteArray# #-}
 

--- a/src/Data/Hash/Class/Mutable/Internal.hs
+++ b/src/Data/Hash/Class/Mutable/Internal.hs
@@ -52,7 +52,6 @@ import Foreign.Storable
 
 import GHC.Exts
 import GHC.IO
-import GHC.Stack
 import GHC.TypeNats
 
 -- -------------------------------------------------------------------------- --
@@ -161,8 +160,7 @@ class KnownNat (DigestSize a) => IncrementalHash a where
         -> IO a
 
     default finalize
-        :: HasCallStack
-        => Coercible a ByteArray
+        :: Coercible a ByteArray
         => Context a
         -> IO a
     finalize ctx = IO $ \s0 -> case newByteArray# size# s0 of

--- a/src/Data/Hash/Class/Mutable/Internal.hs
+++ b/src/Data/Hash/Class/Mutable/Internal.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Mutable.Internal
@@ -28,10 +30,11 @@ module Data.Hash.Class.Mutable.Internal
 , ResetableHash(..)
 ) where
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
-import qualified Data.ByteString.Unsafe as B
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
+import Data.ByteString.Unsafe qualified as B
 import Data.Kind
 import Data.Word
 
@@ -48,8 +51,55 @@ import GHC.IO
 
 class IncrementalHash a where
     type Context a :: Type
-    update :: Context a -> Ptr Word8 -> Int -> IO ()
+
+    -- | It is responsibility of the caller to ensure that the pointer stays
+    -- alive and valid until the function returns.
+    --
+    -- The default implementation is in terms of 'update#' and copies the
+    -- contents of the ptr to a (unpinned) 'ByteArray#'.
+    --
+    updatePtr :: Context a -> Ptr Word8 -> Int -> IO ()
+    updatePtr ctx ptr i = do
+        (BS.SBS arr) <- BS.packCStringLen (castPtr ptr, i)
+        update# @a ctx arr
+    {-# INLINE updatePtr #-}
+
+    -- The implementation must not assume that the array is pinned. If needed
+    -- one may use 'isByteArrayPinned#' to determined whether the array is
+    -- pinned.
+    --
+    -- Note, that since GHC version 8.4 it is sound to make /unsafe/ foreign
+    -- functions calls directly on ByteArray#. GHC will also keep the array
+    -- alive until the end of the unsafe call.
+    --
+    -- Where possible, it is also recommended to /unsafe/ calls in the
+    -- implementation, splitting up possibly long running calls to foreign hash
+    -- implementations on large data into short calls on smaller chunks.
+    --
+    -- The default implementation is in terms of 'update' and has to copy the
+    -- content of array in case it is unpinned. It also ensure that pinned
+    -- arrays are kept alive as long as needed.
+    --
+    update# :: Context a -> ByteArray# -> IO ()
+    update# ctx arr = case isByteArrayPinned# arr of
+        -- Pinned ByteArray. We have to keep it alive. We don't know how update
+        -- is implemented. So just 'touch#' is not an option.
+        1# -> IO $ \s -> keepAlive# arr s $ \s' ->
+            case unIO (updatePtr @a ctx (Ptr (byteArrayContents# arr)) (I# size)) s' of
+                (# s'', () #) -> (# s'', () #)
+
+        -- Unpinned ByteArray, copy content to newly allocated pinned ByteArray
+        _ -> allocaBytes (I# size) $ \ptr@(Ptr addr) -> IO $ \s0 ->
+            case copyByteArrayToAddr# arr 0# addr size s0 of
+                s1 -> case updatePtr @a ctx ptr (I# size) of
+                    IO run -> run s1
+      where
+        size = sizeofByteArray# arr
+    {-# INLINE update# #-}
+
     finalize :: Context a -> IO a
+
+    {-# MINIMAL (updatePtr | update#), finalize #-}
 
 updateByteString
     :: forall a
@@ -58,7 +108,7 @@ updateByteString
     -> B.ByteString
     -> IO ()
 updateByteString ctx b = B.unsafeUseAsCStringLen b $ \(!p, !l) ->
-    update @a ctx (castPtr p) l
+    updatePtr @a ctx (castPtr p) l
 {-# INLINE updateByteString #-}
 
 updateByteStringLazy
@@ -76,8 +126,7 @@ updateShortByteString
     => Context a
     -> BS.ShortByteString
     -> IO ()
-updateShortByteString ctx b = BS.useAsCStringLen b $ \(!p, !l) ->
-    update @a ctx (castPtr p) l
+updateShortByteString ctx (BS.SBS b) = update# @a ctx b
 {-# INLINE updateShortByteString #-}
 
 updateStorable
@@ -87,26 +136,16 @@ updateStorable
     => Context a
     -> b
     -> IO ()
-updateStorable ctx b = with b $ \p -> update @a ctx (castPtr p) (sizeOf b)
+updateStorable ctx b = with b $ \p -> updatePtr @a ctx (castPtr p) (sizeOf b)
 {-# INLINE updateStorable #-}
 
 updateByteArray
     :: forall a
     . IncrementalHash a
     => Context a
-    -> ByteArray#
+    -> ByteArray
     -> IO ()
-updateByteArray ctx a# = case isByteArrayPinned# a# of
-    -- Pinned ByteArray
-    1# -> update @a ctx (Ptr (byteArrayContents# a#)) (I# size#)
-
-    -- Unpinned ByteArray, copy content to newly allocated pinned ByteArray
-    _ -> allocaBytes (I# size#) $ \ptr@(Ptr addr#) -> IO $ \s0 ->
-        case copyByteArrayToAddr# a# 0# addr# size# s0 of
-            s1 -> case update @a ctx ptr (I# size#) of
-                IO run -> run s1
-  where
-    size# = sizeofByteArray# a#
+updateByteArray ctx (ByteArray arr) = update# @a ctx arr
 {-# INLINE updateByteArray #-}
 
 -- -------------------------------------------------------------------------- --

--- a/src/Data/Hash/Class/Mutable/Internal.hs
+++ b/src/Data/Hash/Class/Mutable/Internal.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Mutable.Internal
@@ -20,6 +22,7 @@ module Data.Hash.Class.Mutable.Internal
 (
 -- * Incremental Hashes
   IncrementalHash(..)
+, digestSize
 , updateByteString
 , updateByteStringLazy
 , updateShortByteString
@@ -45,12 +48,16 @@ import Foreign.Storable
 
 import GHC.Exts
 import GHC.IO
+import GHC.TypeNats
 
 -- -------------------------------------------------------------------------- --
 -- Incremental Mutable Hashes
 
-class IncrementalHash a where
+class KnownNat (DigestSize a) => IncrementalHash a where
     type Context a :: Type
+
+    -- | Size of the Digest in Bytes
+    type DigestSize a :: Natural
 
     -- | It is responsibility of the caller to ensure that the pointer stays
     -- alive and valid until the function returns.
@@ -100,6 +107,9 @@ class IncrementalHash a where
     finalize :: Context a -> IO a
 
     {-# MINIMAL (updatePtr | update#), finalize #-}
+
+digestSize :: forall a n . IncrementalHash a => Num n => n
+digestSize = fromIntegral $ natVal' @(DigestSize a) proxy#
 
 updateByteString
     :: forall a

--- a/src/Data/Hash/Class/Mutable/Internal.hs
+++ b/src/Data/Hash/Class/Mutable/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
@@ -33,6 +34,9 @@ module Data.Hash.Class.Mutable.Internal
 , ResetableHash(..)
 ) where
 
+import Control.Monad
+import Control.Exception
+
 import Data.Array.Byte
 import Data.ByteString qualified as B
 import Data.ByteString.Lazy qualified as BL
@@ -48,7 +52,16 @@ import Foreign.Storable
 
 import GHC.Exts
 import GHC.IO
+import GHC.Stack
 import GHC.TypeNats
+
+-- -------------------------------------------------------------------------- --
+-- Exceptions
+
+newtype MutableHashException = MutableHashException String
+    deriving (Show)
+
+instance Exception MutableHashException
 
 -- -------------------------------------------------------------------------- --
 -- Incremental Mutable Hashes
@@ -57,59 +70,186 @@ class KnownNat (DigestSize a) => IncrementalHash a where
     type Context a :: Type
 
     -- | Size of the Digest in Bytes
+    --
     type DigestSize a :: Natural
 
-    -- | It is responsibility of the caller to ensure that the pointer stays
-    -- alive and valid until the function returns.
+    -- | Update the hash context with the contents of a Ptr.
+    --
+    -- It is responsibility of the caller to ensure that the pointer is valid
+    -- during the operations. In particular, if the pointer points to memory on
+    -- the Haskell heap, that memory must be pinned and must be kept alive.
     --
     -- The default implementation is in terms of 'update#' and copies the
-    -- contents of the ptr to a (unpinned) 'ByteArray#'.
+    -- contents of the ptr to an unpinned 'ByteArray#'.
     --
-    updatePtr :: Context a -> Ptr Word8 -> Int -> IO ()
-    updatePtr ctx ptr i = do
+    updatePtr
+        :: Context a
+            -- ^ The mutable hash context
+        -> Ptr Word8
+            -- ^ Pointer to the input data
+        -> Int
+            -- ^ The size of the input data in bytes
+        -> IO ()
+    updatePtr ctx ptr !i@(I# i#) = do
         (BS.SBS arr) <- BS.packCStringLen (castPtr ptr, i)
-        update# @a ctx arr
+        update# @a ctx arr 0# i#
     {-# INLINE updatePtr #-}
 
-    -- The implementation must not assume that the array is pinned. If needed
-    -- one may use 'isByteArrayPinned#' to determined whether the array is
-    -- pinned.
+    -- | Update the hash context with the contents of a (possibly unpinned)
+    -- ByteArray# at the given offset.
     --
-    -- Note, that since GHC version 8.4 it is sound to make /unsafe/ foreign
-    -- functions calls directly on ByteArray#. GHC will also keep the array
-    -- alive until the end of the unsafe call.
+    -- It is the responsibility of the caller to guarantee that the range
+    -- @[offset, offset+length-1]@ is indeed in the array. The implementation
+    -- may check that but that is not a requirement.
     --
-    -- Where possible, it is also recommended to /unsafe/ calls in the
-    -- implementation, splitting up possibly long running calls to foreign hash
-    -- implementations on large data into short calls on smaller chunks.
+    -- The implementation must not assume that the array is pinned.
     --
-    -- The default implementation is in terms of 'update' and has to copy the
+    -- Since GHC version 8.4 it it is sound to make /unsafe/ foreign functions
+    -- calls directly on ByteArray#. GHC will also keep the array alive until
+    -- the end of the unsafe call.
+    --
+    -- When possible, it is also recommended to use /unsafe/ calls in the
+    -- implementation. Possibly long running calls to foreign hash
+    -- implementations on large data may be split into short calls on smaller
+    -- chunks.
+    --
+    -- The default implementation is in terms of 'updatePtr' and has to copy the
     -- content of array in case it is unpinned. It also ensure that pinned
     -- arrays are kept alive as long as needed.
     --
-    update# :: Context a -> ByteArray# -> IO ()
-    update# ctx arr = case isByteArrayPinned# arr of
-        -- Pinned ByteArray. We have to keep it alive. We don't know how update
-        -- is implemented. So just 'touch#' is not an option.
-        1# -> IO $ \s -> keepAlive# arr s $ \s' ->
-            case unIO (updatePtr @a ctx (Ptr (byteArrayContents# arr)) (I# size)) s' of
-                (# s'', () #) -> (# s'', () #)
+    update#
+        :: Context a
+            -- ^ The mutable hash context
+        -> ByteArray#
+            -- ^ The (possibly unpinned) byte array with the input data
+        -> Int#
+            -- ^ The offset into the input byte array
+        -> Int#
+            -- ^ The size of the input data in bytes
+        -> IO ()
+    update# ctx arr# off# len# = do
+        -- Assert that the addressed memory is within the input array
+        when (isTrue# (size# <# off# +# len#)) $
+            throwIO $ MutableHashException "input array to small"
 
-        -- Unpinned ByteArray, copy content to newly allocated pinned ByteArray
-        _ -> allocaBytes (I# size) $ \ptr@(Ptr addr) -> IO $ \s0 ->
-            case copyByteArrayToAddr# arr 0# addr size s0 of
-                s1 -> case updatePtr @a ctx ptr (I# size) of
-                    IO run -> run s1
+        if isTrue# (isByteArrayPinned# arr#)
+          then
+            -- Pinned ByteArray. We have to keep it alive. We don't know how
+            -- updatePtr is implemented. So just 'touch#' is not an option.
+            IO $ \s0 -> keepAlive# arr# s0 $ \s1 ->
+                case unIO (updatePtr @a ctx (Ptr contAddr) (I# len#)) s1 of
+                    (# s2, () #) -> (# s2, () #)
+          else
+            -- Unpinned ByteArray, copy content to temporarily allocated memory
+            allocaBytes (I# len#) $ \ptr@(Ptr addr) -> IO $ \s0 ->
+                case copyByteArrayToAddr# arr# off# addr len# s0 of
+                    s1 -> case unIO (updatePtr @a ctx ptr (I# len#)) s1 of
+                        (# s2, () #) -> (# s2, () #)
       where
-        size = sizeofByteArray# arr
-    {-# INLINE update# #-}
+        size# = sizeofByteArray# arr#
+        contAddr = plusAddr# (byteArrayContents# arr#) off#
+    {-# INLINEABLE update# #-}
 
-    finalize :: Context a -> IO a
+    -- | Finalize a hash computation and return the digest.
+    --
+    -- The default implementation is in terms of finalize# and requires that the
+    -- type of the digest can be coerced from 'ByteArray'.
+    --
+    finalize
+        :: Context a
+            -- The mutable hash context
+        -> IO a
 
-    {-# MINIMAL (updatePtr | update#), finalize #-}
+    default finalize
+        :: HasCallStack
+        => Coercible a ByteArray
+        => Context a
+        -> IO a
+    finalize ctx = IO $ \s0 -> case newByteArray# size# s0 of
+        (# s1, a# #) -> case unIO (finalize# @a ctx a# 0#) s1 of
+            (# s2, () #) -> case unsafeFreezeByteArray# a# s2 of
+                (# s3, b# #) -> (# s3, coerce (ByteArray b#) #)
+      where
+        !(I# size#) = digestSize @a
+    {-# INLINEABLE finalize #-}
+
+    -- | Finalize a hash computation and write the digest bytes to the given
+    -- 'MutableByteArray#' at the given offset.
+    --
+    -- This API can be beneficial if many nested hashes are computed, for
+    -- instance during verification of Merkle proofs.
+    --
+    -- It is the responsiblility of the caller to guarantee that the result
+    -- array is large enough. Implementations may check and fail gracefully, but
+    -- this is not required.
+    --
+    -- The default implementation is in terms of 'finalPtr' and has to copy the
+    -- content of array in case it is unpinned. It also ensures that pinned
+    -- arrays are kept alive as long as needed.
+    --
+    finalize#
+        :: Context a
+            -- ^ The mutable hash context
+        -> MutableByteArray# RealWorld
+            -- ^ A (possibly unpinned) mutable byte array into which the digest
+            -- is written
+        -> Int#
+            -- ^ The offset in the byte array at which the digest is written
+        -> IO ()
+
+    finalize# ctx arr# offset# = do
+        asize <- IO $ \s -> case getSizeofMutableByteArray# arr# s of
+            (# s', n# #) -> (# s', I# (n# -# offset#) #)
+        when (asize < size) $
+            throwIO $ MutableHashException "output array to small for the digest"
+
+        if isTrue# (isMutableByteArrayPinned# arr#)
+          then
+            IO $ \s0 -> keepAlive# arr# s0 $ \s1 ->
+                case unIO (finalizePtr @a ctx (Ptr trgAddr#)) s1 of
+                    (# s2, () #) -> (# s2, () #)
+
+          else
+            allocaBytes size $ \ptr@(Ptr addr) -> IO $ \s0 ->
+                case unIO (finalizePtr @a ctx ptr) s0 of
+                    (# s1, () #) -> case copyAddrToByteArray# addr arr# offset# size# s1 of
+                        s2 -> (# s2, () #)
+      where
+        !size@(I# size#) = digestSize @a
+        trgAddr# = plusAddr# (mutableByteArrayContents# arr#) offset#
+    {-# INLINEABLE finalize# #-}
+
+    -- | Finalize a hash computation and write the digest bytes to the given
+    -- 'Ptr'.
+    --
+    -- It is the responsiblility of the caller to guarantee that there is enough
+    -- allocated space availale at the given Ptr and the pointer remains valid
+    -- during the operation. In particular, if the pointer points into the
+    -- Haskell keep the memory must be pinned and kept alive.
+    --
+    -- The default implementation is in terms of 'finalize#' and copies the
+    -- resulting digest bytes to the Ptr.
+    --
+    finalizePtr
+        :: Context a
+            -- ^ The mutable hash context
+        -> Ptr Word8
+            -- ^ Pointer to the memory location where the digest is written to
+        -> IO ()
+    finalizePtr ctx (Ptr addr#) = do
+        IO $ \s0 -> case newByteArray# size# s0 of
+            (# s1, a# #) -> case unIO (finalize# @a ctx a# 0#) s1 of
+                (# s2, () #) -> case copyMutableByteArrayToAddr# a# 0# addr# size# s2 of
+                    s3 -> (# s3, () #)
+      where
+        !(I# size#) = digestSize @a
+    {-# INLINEABLE finalizePtr #-}
+
+    {-# MINIMAL (updatePtr | update#), (finalize# | finalizePtr) #-}
 
 digestSize :: forall a n . IncrementalHash a => Num n => n
 digestSize = fromIntegral $ natVal' @(DigestSize a) proxy#
+{-# INLINE digestSize #-}
 
 updateByteString
     :: forall a
@@ -136,7 +276,7 @@ updateShortByteString
     => Context a
     -> BS.ShortByteString
     -> IO ()
-updateShortByteString ctx (BS.SBS b) = update# @a ctx b
+updateShortByteString ctx !(BS.SBS b#) = update# @a ctx b# 0# (sizeofByteArray# b#)
 {-# INLINE updateShortByteString #-}
 
 updateStorable
@@ -155,7 +295,7 @@ updateByteArray
     => Context a
     -> ByteArray
     -> IO ()
-updateByteArray ctx (ByteArray arr) = update# @a ctx arr
+updateByteArray ctx !(ByteArray b#) = update# @a ctx b# 0# (sizeofByteArray# b#)
 {-# INLINE updateByteArray #-}
 
 -- -------------------------------------------------------------------------- --

--- a/src/Data/Hash/Class/Mutable/Salted.hs
+++ b/src/Data/Hash/Class/Mutable/Salted.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Mutable.Salted
@@ -22,6 +23,7 @@ module Data.Hash.Class.Mutable.Salted
 , hashByteStringLazy
 , hashShortByteString
 , hashByteArray
+, hashByteArray#
 
 -- ** Pure variants of hash functions
 --
@@ -38,6 +40,7 @@ module Data.Hash.Class.Mutable.Salted
 , hashByteStringLazy_
 , hashShortByteString_
 , hashByteArray_
+, hashByteArray_#
 
 -- * Incremental Hashing
 , updateByteString
@@ -47,9 +50,10 @@ module Data.Hash.Class.Mutable.Salted
 , updateByteArray
 ) where
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
 import Data.Kind
 import Data.Word
 
@@ -76,7 +80,7 @@ class IncrementalHash a => Hash a where
 hashPtr :: forall a . Hash a => Salt a -> Ptr Word8 -> Int -> IO a
 hashPtr k p n = do
     ctx <- initialize @a k
-    update @a ctx p n
+    updatePtr @a ctx p n
     finalize ctx
 {-# INLINE hashPtr #-}
 
@@ -108,12 +112,19 @@ hashStorable k b = do
         finalize ctx
 {-# INLINE hashStorable #-}
 
-hashByteArray :: forall a . Hash a => Salt a -> ByteArray# -> IO a
+hashByteArray :: forall a . Hash a => Salt a -> ByteArray -> IO a
 hashByteArray k b = do
         ctx <- initialize @a k
         updateByteArray @a ctx b
         finalize ctx
 {-# INLINE hashByteArray #-}
+
+hashByteArray# :: forall a . Hash a => Salt a -> ByteArray# -> IO a
+hashByteArray# k b = do
+        ctx <- initialize @a k
+        update# @a ctx b
+        finalize ctx
+{-# INLINE hashByteArray# #-}
 
 -- -------------------------------------------------------------------------- --
 -- Pure variants
@@ -138,7 +149,11 @@ hashStorable_ :: forall a b . Hash a => Storable b => Salt a -> b -> a
 hashStorable_ s = unsafePerformIO . hashStorable s
 {-# INLINE hashStorable_ #-}
 
-hashByteArray_ :: forall a . Hash a => Salt a -> ByteArray# -> a
+hashByteArray_ :: forall a . Hash a => Salt a -> ByteArray -> a
 hashByteArray_ s a = unsafePerformIO $ hashByteArray s a
 {-# INLINE hashByteArray_ #-}
+
+hashByteArray_# :: forall a . Hash a => Salt a -> ByteArray# -> a
+hashByteArray_# s a = unsafePerformIO $ hashByteArray# s a
+{-# INLINE hashByteArray_# #-}
 

--- a/src/Data/Hash/Class/Mutable/Salted.hs
+++ b/src/Data/Hash/Class/Mutable/Salted.hs
@@ -17,6 +17,7 @@
 module Data.Hash.Class.Mutable.Salted
 ( Hash(..)
 
+, digestSize
 , hashPtr
 , hashStorable
 , hashByteString

--- a/src/Data/Hash/Class/Mutable/Salted.hs
+++ b/src/Data/Hash/Class/Mutable/Salted.hs
@@ -120,9 +120,9 @@ hashByteArray k b = do
 {-# INLINE hashByteArray #-}
 
 hashByteArray# :: forall a . Hash a => Salt a -> ByteArray# -> IO a
-hashByteArray# k b = do
+hashByteArray# k b# = do
         ctx <- initialize @a k
-        update# @a ctx b
+        update# @a ctx b# 0# (sizeofByteArray# b#)
         finalize ctx
 {-# INLINE hashByteArray# #-}
 

--- a/src/Data/Hash/Class/Pure.hs
+++ b/src/Data/Hash/Class/Pure.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,6 +16,7 @@
 module Data.Hash.Class.Pure
 ( Hash(..)
 , IncrementalHash(..)
+, digestSize
 
 , hashPtr
 , hashStorable
@@ -22,6 +24,7 @@ module Data.Hash.Class.Pure
 , hashByteStringLazy
 , hashShortByteString
 , hashByteArray
+, hashByteArray#
 
 -- * Incremental Hashing
 , updateByteString
@@ -36,15 +39,18 @@ module Data.Hash.Class.Pure
 
 import Control.Monad
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
 import Data.Word
 
 import Foreign.Ptr
 import Foreign.Storable
 
 import GHC.Exts
+
+import System.IO.Unsafe
 
 -- internal modules
 
@@ -60,7 +66,7 @@ class IncrementalHash a => Hash a where
 -- hash Functions
 
 hashPtr :: forall a. Hash a => Ptr Word8 -> Int -> IO a
-hashPtr p n = finalize <$!> update @a (initialize @a) p n
+hashPtr p n = finalize <$!> updatePtr @a (initialize @a) p n
 {-# INLINE hashPtr #-}
 
 hashByteString :: forall a . Hash a => B.ByteString -> a
@@ -79,9 +85,15 @@ hashStorable :: forall a b . Hash a => Storable b => b -> a
 hashStorable b = finalize $! updateStorable @a (initialize @a) b
 {-# INLINE hashStorable #-}
 
-hashByteArray :: forall a . Hash a => ByteArray# -> a
+hashByteArray :: forall a . Hash a => ByteArray -> a
 hashByteArray b = finalize $! updateByteArray @a (initialize @a) b
 {-# INLINE hashByteArray #-}
+
+hashByteArray# :: forall a . Hash a => ByteArray# -> a
+hashByteArray# b = finalize $! unsafeDupablePerformIO $
+    update# @a (initialize @a) b 0# (sizeofByteArray# b)
+
+{-# INLINE hashByteArray# #-}
 
 -- -------------------------------------------------------------------------- --
 -- Utilities

--- a/src/Data/Hash/Class/Pure/Internal.hs
+++ b/src/Data/Hash/Class/Pure/Internal.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Data.Hash.Class.Pure.Internal
@@ -16,6 +21,7 @@
 --
 module Data.Hash.Class.Pure.Internal
 ( IncrementalHash(..)
+, digestSize
 , updateByteString
 , updateByteStringLazy
 , updateShortByteString
@@ -23,10 +29,14 @@ module Data.Hash.Class.Pure.Internal
 , updateByteArray
 ) where
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
-import qualified Data.ByteString.Unsafe as B
+import Control.Exception
+import Control.Monad
+
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
+import Data.ByteString.Unsafe qualified as B
 import Data.Kind
 import Data.Word
 
@@ -37,18 +47,121 @@ import Foreign.Storable
 
 import GHC.Exts
 import GHC.IO
+import GHC.TypeNats
 
--- -------------------------------------------------------------------------- --
+---- -------------------------------------------------------------------------- --
+-- Exceptions
+
+newtype PureHashException = PureHashException String
+    deriving (Show)
+
+instance Exception PureHashException
+
+ -------------------------------------------------------------------------- --
 -- Incremental Pure Hashes
 
-class IncrementalHash a where
+class KnownNat (DigestSize a) => IncrementalHash a where
     type Context a :: Type
-    update :: Context a -> Ptr Word8 -> Int -> IO (Context a)
+
+    -- | Size of the Digest in Bytes
+    --
+    type DigestSize a :: Natural
+
+    -- | Update the hash context with the contents of a Ptr.
+    --
+    -- It is responsibility of the caller to ensure that the pointer is valid
+    -- during the operations. In particular, if the pointer points to memory on
+    -- the Haskell heap, that memory must be pinned and must be kept alive.
+    --
+    -- The default implementation is in terms of 'update#' and copies the
+    -- contents of the ptr to an unpinned 'ByteArray#'.
+    --
+    updatePtr
+        :: Context a
+            -- ^ the hash context
+        -> Ptr Word8
+            -- ^ Pointer to the input data
+        -> Int
+            -- ^ The size of the input data in bytes
+        -> IO (Context a)
+    updatePtr ctx ptr !i@(I# i#) = do
+        (BS.SBS arr) <- BS.packCStringLen (castPtr ptr, i)
+        update# @a ctx arr 0# i#
+    {-# INLINE updatePtr #-}
+
+    -- | Update the hash context with the contents of a (possibly unpinned)
+    -- ByteArray# at the given offset.
+    --
+    -- It is the responsibility of the caller to guarantee that the range
+    -- @[offset, offset+length-1]@ is indeed in the array. The implementation
+    -- may check that but that is not a requirement.
+    --
+    -- The implementation must not assume that the array is pinned.
+    --
+    -- Since GHC version 8.4 it it is sound to make /unsafe/ foreign functions
+    -- calls directly on ByteArray#. GHC will also keep the array alive until
+    -- the end of the unsafe call.
+    --
+    -- When possible, it is also recommended to use /unsafe/ calls in the
+    -- implementation. Possibly long running calls to foreign hash
+    -- implementations on large data may be split into short calls on smaller
+    -- chunks.
+    --
+    -- The default implementation is in terms of 'updatePtr' and has to copy the
+    -- content of array in case it is unpinned. It also ensure that pinned
+    -- arrays are kept alive as long as needed.
+    --
+    update#
+        :: Context a
+            -- ^ The hash context
+        -> ByteArray#
+            -- ^ The (possibly unpinned) byte array with the input data
+        -> Int#
+            -- ^ The offset into the input byte array
+        -> Int#
+            -- ^ The size of the input data in bytes
+        -> IO (Context a)
+    update# ctx arr# off# len# = do
+        -- Assert that the addressed memory is within the input array
+        when (isTrue# (size# <# off# +# len#)) $
+            throwIO $ PureHashException "input array to small"
+
+        if isTrue# (isByteArrayPinned# arr#)
+          then
+            -- Pinned ByteArray. We have to keep it alive. We don't know how
+            -- updatePtr is implemented. So just 'touch#' is not an option.
+            IO $ \s0 -> keepAlive# arr# s0 $ \s1 ->
+                case unIO (updatePtr @a ctx (Ptr contAddr) (I# len#)) s1 of
+                    (# s2, ctx' #) -> (# s2, ctx' #)
+          else
+            -- Unpinned ByteArray, copy content to temporarily allocated memory
+            allocaBytes (I# len#) $ \ptr@(Ptr addr) -> IO $ \s0 ->
+                case copyByteArrayToAddr# arr# off# addr len# s0 of
+                    s1 -> case unIO (updatePtr @a ctx ptr (I# len#)) s1 of
+                        (# s2, ctx' #) -> (# s2, ctx' #)
+      where
+        size# = sizeofByteArray# arr#
+        contAddr = plusAddr# (byteArrayContents# arr#) off#
+    {-# INLINEABLE update# #-}
+
+    -- | Finalize a hash computation and return the digest.
+    --
     finalize :: Context a -> a
 
-updateByteString :: forall a . IncrementalHash a => Context a -> B.ByteString -> Context a
+    {-# MINIMAL (updatePtr | update#), finalize #-}
+
+digestSize :: forall a n . IncrementalHash a => Num n => n
+digestSize = fromIntegral $ natVal' @(DigestSize a) proxy#
+{-# INLINE digestSize #-}
+
+updateByteString
+    :: forall a
+    . IncrementalHash a
+    => Context a
+    -> B.ByteString
+    -> Context a
 updateByteString !ctx !b = unsafeDupablePerformIO $!
-    B.unsafeUseAsCStringLen b $ \(!p, !l) -> update @a ctx (castPtr p) l
+    B.unsafeUseAsCStringLen b $ \(!p, !l) -> updatePtr @a ctx (castPtr p) l
 {-# INLINE updateByteString #-}
 
 updateByteStringLazy
@@ -66,8 +179,8 @@ updateShortByteString
     => Context a
     -> BS.ShortByteString
     -> Context a
-updateShortByteString !ctx b = unsafeDupablePerformIO $!
-    BS.useAsCStringLen b $ \(!p, !l) -> update @a ctx (castPtr p) l
+updateShortByteString !ctx !(BS.SBS b#) = unsafeDupablePerformIO $!
+    update# @a ctx b# 0# (sizeofByteArray# b#)
 {-# INLINE updateShortByteString #-}
 
 updateStorable
@@ -78,26 +191,16 @@ updateStorable
     -> b
     -> Context a
 updateStorable !ctx b = unsafeDupablePerformIO $!
-    with b $ \p -> update @a ctx (castPtr p) (sizeOf b)
+    with b $ \p -> updatePtr @a ctx (castPtr p) (sizeOf b)
 {-# INLINE updateStorable #-}
 
 updateByteArray
     :: forall a
     . IncrementalHash a
     => Context a
-    -> ByteArray#
+    -> ByteArray
     -> Context a
-updateByteArray ctx a# = unsafeDupablePerformIO $!
-    case isByteArrayPinned# a# of
-        -- Pinned ByteArray
-        1# -> update @a ctx (Ptr (byteArrayContents# a#)) (I# size#)
-
-        -- Unpinned ByteArray, copy content to newly allocated pinned ByteArray
-        _ -> allocaBytes (I# size#) $ \ptr@(Ptr addr#) -> IO $ \s0 ->
-            case copyByteArrayToAddr# a# 0# addr# size# s0 of
-                s1 -> case update @a ctx ptr (I# size#) of
-                    IO run -> run s1
-  where
-    size# = sizeofByteArray# a#
+updateByteArray ctx !(ByteArray b#) = unsafeDupablePerformIO $!
+    update# @a ctx b# 0# (sizeofByteArray# b#)
 {-# INLINE updateByteArray #-}
 

--- a/src/Data/Hash/Class/Pure/Salted.hs
+++ b/src/Data/Hash/Class/Pure/Salted.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,6 +15,7 @@
 module Data.Hash.Class.Pure.Salted
 ( Hash(..)
 , IncrementalHash(..)
+, digestSize
 
 , hashPtr
 , hashStorable
@@ -21,6 +23,7 @@ module Data.Hash.Class.Pure.Salted
 , hashByteStringLazy
 , hashShortByteString
 , hashByteArray
+, hashByteArray#
 
 -- * Incremental Hashing
 , updateByteString
@@ -32,9 +35,10 @@ module Data.Hash.Class.Pure.Salted
 
 import Control.Monad
 
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
+import Data.Array.Byte
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
 import Data.Kind
 import Data.Word
 
@@ -42,6 +46,8 @@ import Foreign.Ptr
 import Foreign.Storable
 
 import GHC.Exts
+
+import System.IO.Unsafe
 
 -- internal modules
 
@@ -58,7 +64,7 @@ class IncrementalHash a => Hash a where
 -- hash Functions
 
 hashPtr :: forall a. Hash a => Salt a -> Ptr Word8 -> Int -> IO a
-hashPtr k p n = finalize <$!> update @a (initialize @a k) p n
+hashPtr k p n = finalize <$!> updatePtr @a (initialize @a k) p n
 {-# INLINE hashPtr #-}
 
 hashByteString :: forall a . Hash a => Salt a -> B.ByteString -> a
@@ -77,7 +83,12 @@ hashStorable :: forall a b . Hash a => Storable b => Salt a -> b -> a
 hashStorable k b = finalize $! updateStorable @a (initialize @a k) b
 {-# INLINE hashStorable #-}
 
-hashByteArray :: forall a . Hash a => Salt a -> ByteArray# -> a
+hashByteArray :: forall a . Hash a => Salt a -> ByteArray -> a
 hashByteArray k b = finalize $! updateByteArray @a (initialize @a k) b
 {-# INLINE hashByteArray #-}
+
+hashByteArray# :: forall a . Hash a => Salt a -> ByteArray# -> a
+hashByteArray# k b = finalize $! unsafeDupablePerformIO $
+    update# @a (initialize @a k) b 0# (sizeofByteArray# b)
+{-# INLINE hashByteArray# #-}
 

--- a/src/Data/Hash/FNV1.hs
+++ b/src/Data/Hash/FNV1.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 
 -- |
 -- Module: Data.Hash.FNV1
@@ -115,6 +117,11 @@ import Foreign.Storable
 
 import GHC.Exts
 import GHC.IO
+#if !(defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH) || defined(i386_HOST_ARCH))
+import GHC.TypeLits
+#endif
+
+import Numeric.Natural
 
 -- internal modules
 
@@ -147,10 +154,11 @@ fnv164 !ptr !n = fnv164Finalize <$!> fnv164Update fnv164Initialize ptr n
 
 instance IncrementalHash Fnv164Hash where
     type Context Fnv164Hash = Fnv164Context
-    update = fnv164Update
+    type DigestSize Fnv164Hash = 8
+    updatePtr = fnv164Update
     finalize = fnv164Finalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv164Hash where
@@ -184,10 +192,11 @@ fnv1a64 !ptr !n = fnv1a64Finalize <$!> fnv1a64Update fnv1a64Initialize ptr n
 
 instance IncrementalHash Fnv1a64Hash where
     type Context Fnv1a64Hash = Fnv1a64Context
-    update = fnv1a64Update
+    type DigestSize Fnv1a64Hash = 8
+    updatePtr = fnv1a64Update
     finalize = fnv1a64Finalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv1a64Hash where
@@ -221,10 +230,11 @@ fnv132 !ptr !n = fnv132Finalize <$!> fnv132Update fnv132Initialize ptr n
 
 instance IncrementalHash Fnv132Hash where
     type Context Fnv132Hash = Fnv132Context
-    update = fnv132Update
+    type DigestSize Fnv132Hash = 4
+    updatePtr = fnv132Update
     finalize = fnv132Finalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv132Hash where
@@ -258,10 +268,11 @@ fnv1a32 !ptr !n = fnv1a32Finalize <$!> fnv1a32Update fnv1a32Initialize ptr n
 
 instance IncrementalHash Fnv1a32Hash where
     type Context Fnv1a32Hash = Fnv1a32Context
-    update = fnv1a32Update
+    type DigestSize Fnv1a32Hash = 4
+    updatePtr = fnv1a32Update
     finalize = fnv1a32Finalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv1a32Hash where
@@ -295,10 +306,11 @@ fnv1 !ptr !n = fnv1Finalize <$!> fnv1Update fnv1Initialize ptr n
 
 instance IncrementalHash Fnv1Hash where
     type Context Fnv1Hash = Fnv1Context
-    update = fnv1Update
+    type DigestSize Fnv1Hash = WORD_SIZE
+    updatePtr = fnv1Update
     finalize = fnv1Finalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv1Hash where
@@ -332,10 +344,11 @@ fnv1a !ptr !n = fnv1aFinalize <$!> fnv1aUpdate fnv1aInitialize ptr n
 
 instance IncrementalHash Fnv1aHash where
     type Context Fnv1aHash = Fnv1aContext
-    update = fnv1aUpdate
+    type DigestSize Fnv1aHash = WORD_SIZE
+    updatePtr = fnv1aUpdate
     finalize = fnv1aFinalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance Hash Fnv1aHash where
@@ -345,6 +358,15 @@ instance Hash Fnv1aHash where
 -- -------------------------------------------------------------------------- --
 -- Low Level
 -- -------------------------------------------------------------------------- --
+
+type WORD_SIZE :: Natural
+#if defined(x86_64_HOST_ARCH) || defined(aarch64_HOST_ARCH)
+type WORD_SIZE = 8
+#elif defined(i386_HOST_ARCH)
+type WORD_SIZE = 4
+#else
+type WORD_SIZE = TypeError (Text "unsupported hardware platform")
+#endif
 
 -- -------------------------------------------------------------------------- --
 -- Constants

--- a/src/Data/Hash/Internal/OpenSSL.hs
+++ b/src/Data/Hash/Internal/OpenSSL.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
@@ -190,7 +191,8 @@ newtype Algorithm a = Algorithm (ForeignPtr Void)
 instance Typeable a => Show (Algorithm a) where
     show _ = show (typeRep (Nothing @a))
 
-class OpenSslDigest a where
+class KnownNat (OpenSslDigestSize a) => OpenSslDigest a where
+    type OpenSslDigestSize a :: Natural
     algorithm :: Algorithm a
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -369,15 +371,16 @@ instance OpenSslDigest a => Hash (Digest a) where
     initialize = initCtx (algorithm @a)
     {-# INLINE initialize #-}
 
-instance IncrementalHash (Digest a) where
+instance OpenSslDigest a => IncrementalHash (Digest a) where
     type Context (Digest a) = Ctx a
+    type DigestSize (Digest a) = OpenSslDigestSize a
     updatePtr = updateCtx
     update# = updateCtx#
     finalize = finalCtx
     {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
-instance ResetableHash (Digest a) where
+instance OpenSslDigest a => ResetableHash (Digest a) where
     reset = resetCtx
     {-# INLINE reset #-}
 
@@ -414,6 +417,7 @@ xof_finalCtx (Ctx ctx) = withForeignPtr ctx $ \ptr -> do
 
 instance KnownNat n => IncrementalHash (XOF_Digest n a) where
     type Context (XOF_Digest n a) = Ctx a
+    type DigestSize (XOF_Digest n a) = n
     updatePtr = updateCtx
     update# = updateCtx#
     finalize = xof_finalCtx
@@ -508,37 +512,49 @@ newtype Sha2_224 = Sha2_224 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_224)
-instance OpenSslDigest Sha2_224 where algorithm = sha2_224
+instance OpenSslDigest Sha2_224 where
+    type OpenSslDigestSize Sha2_224 = 28
+    algorithm = sha2_224
 
 newtype Sha2_256 = Sha2_256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_256)
-instance OpenSslDigest Sha2_256 where algorithm = sha2_256
+instance OpenSslDigest Sha2_256 where
+    type OpenSslDigestSize Sha2_256 = 32
+    algorithm = sha2_256
 
 newtype Sha2_384 = Sha2_384 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_384)
-instance OpenSslDigest Sha2_384 where algorithm = sha2_384
+instance OpenSslDigest Sha2_384 where
+    type OpenSslDigestSize Sha2_384 = 48
+    algorithm = sha2_384
 
 newtype Sha2_512 = Sha2_512 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512)
-instance OpenSslDigest Sha2_512 where algorithm = sha2_512
+instance OpenSslDigest Sha2_512 where
+    type OpenSslDigestSize Sha2_512 = 64
+    algorithm = sha2_512
 
 newtype Sha2_512_224 = Sha2_512_224 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512_224)
-instance OpenSslDigest Sha2_512_224 where algorithm = sha2_512_224
+instance OpenSslDigest Sha2_512_224 where
+    type OpenSslDigestSize Sha2_512_224 = 28
+    algorithm = sha2_512_224
 
 newtype Sha2_512_256 = Sha2_512_256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512_256)
-instance OpenSslDigest Sha2_512_256 where algorithm = sha2_512_256
+instance OpenSslDigest Sha2_512_256 where
+    type OpenSslDigestSize Sha2_512_256 = 32
+    algorithm = sha2_512_256
 
 -- -------------------------------------------------------------------------- --
 -- SHA-3
@@ -582,37 +598,49 @@ newtype Sha3_224 = Sha3_224 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_224)
-instance OpenSslDigest Sha3_224 where algorithm = sha3_224
+instance OpenSslDigest Sha3_224 where
+    type OpenSslDigestSize Sha3_224 = 28
+    algorithm = sha3_224
 
 newtype Sha3_256 = Sha3_256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_256)
-instance OpenSslDigest Sha3_256 where algorithm = sha3_256
+instance OpenSslDigest Sha3_256 where
+    type OpenSslDigestSize Sha3_256 = 32
+    algorithm = sha3_256
 
 newtype Sha3_384 = Sha3_384 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_384)
-instance OpenSslDigest Sha3_384 where algorithm = sha3_384
+instance OpenSslDigest Sha3_384 where
+    type OpenSslDigestSize Sha3_384 = 48
+    algorithm = sha3_384
 
 newtype Sha3_512 = Sha3_512 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_512)
-instance OpenSslDigest Sha3_512 where algorithm = sha3_512
+instance OpenSslDigest Sha3_512 where
+    type OpenSslDigestSize Sha3_512 = 64
+    algorithm = sha3_512
 
 newtype Shake128 (bits :: Natural) = Shake128 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest bits (Shake128 bits))
-instance OpenSslDigest (Shake128 n) where algorithm = shake128
+instance KnownNat n => OpenSslDigest (Shake128 n) where
+    type OpenSslDigestSize (Shake128 n) = n
+    algorithm = shake128
 
 newtype Shake256 (bits :: Natural) = Shake256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest bits (Shake256 bits))
-instance OpenSslDigest (Shake256 n) where algorithm = shake256
+instance KnownNat n => OpenSslDigest (Shake256 n) where
+    type OpenSslDigestSize (Shake256 n) = n
+    algorithm = shake256
 
 type Shake128_256 = Shake128 32
 type Shake256_512 = Shake256 64
@@ -675,25 +703,33 @@ newtype Keccak224 = Keccak224 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak224)
-instance OpenSslDigest Keccak224 where algorithm = keccak_224
+instance OpenSslDigest Keccak224 where
+    type OpenSslDigestSize Keccak224 = 28
+    algorithm = keccak_224
 
 newtype Keccak256 = Keccak256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak256)
-instance OpenSslDigest Keccak256 where algorithm = keccak_256
+instance OpenSslDigest Keccak256 where
+    type OpenSslDigestSize Keccak256 = 32
+    algorithm = keccak_256
 
 newtype Keccak384 = Keccak384 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak384)
-instance OpenSslDigest Keccak384 where algorithm = keccak_384
+instance OpenSslDigest Keccak384 where
+    type OpenSslDigestSize Keccak384 = 48
+    algorithm = keccak_384
 
 newtype Keccak512 = Keccak512 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak512)
-instance OpenSslDigest Keccak512 where algorithm = keccak_512
+instance OpenSslDigest Keccak512 where
+    type OpenSslDigestSize Keccak512 = 64
+    algorithm = keccak_512
 
 -- | Low-Level function that writes the final digest directly into the provided
 -- pointer. The pointer must point to at least 64 bytes of allocated memory.
@@ -753,11 +789,15 @@ newtype Blake2b512 = Blake2b512 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash) via (Digest Blake2b512)
-instance OpenSslDigest Blake2b512 where algorithm = blake2b512
+instance OpenSslDigest Blake2b512 where
+    type OpenSslDigestSize Blake2b512 = 64
+    algorithm = blake2b512
 
 newtype Blake2s256 = Blake2s256 BS.ShortByteString
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash) via (Digest Blake2s256)
-instance OpenSslDigest Blake2s256 where algorithm = blake2s256
+instance OpenSslDigest Blake2s256 where
+    type OpenSslDigestSize Blake2s256 = 32
+    algorithm = blake2s256
 

--- a/src/Data/Hash/Internal/OpenSSL.hs
+++ b/src/Data/Hash/Internal/OpenSSL.hs
@@ -172,18 +172,22 @@ pattern ConstPtr a = a
 
 withConstCString :: String -> (ConstCString -> IO a) -> IO a
 withConstCString str inner = withCString str $ \cstr -> inner (ConstPtr cstr)
+{-# INLINE withConstCString #-}
 
 constPtr :: Addr# -> ConstPtr a
 constPtr a = ConstPtr (Ptr a)
+{-# INLINE constPtr #-}
 
 nullConstPtr :: ConstPtr a
 nullConstPtr = ConstPtr nullPtr
+{-# INLINE nullConstPtr #-}
 
 -- -------------------------------------------------------------------------- --
 -- Misc utils
 
 toCSize# :: Int# -> CSize
 toCSize# i# = fromIntegral (I# i#)
+{-# INLINE toCSize# #-}
 
 -- -------------------------------------------------------------------------- --
 -- OpenSSL Message Digest Algorithms

--- a/src/Data/Hash/Internal/OpenSSL.hs
+++ b/src/Data/Hash/Internal/OpenSSL.hs
@@ -1,16 +1,21 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
@@ -44,8 +49,10 @@ module Data.Hash.Internal.OpenSSL
 , Digest(..)
 , resetCtx
 , initCtx
-, updateCtx
-, finalCtx
+, updateCtxPtr
+, updateCtx#
+, finalCtxPtr
+, finalCtx#
 , fetchAlgorithm
 
 -- * Algorithms
@@ -86,10 +93,6 @@ module Data.Hash.Internal.OpenSSL
 , Keccak384(..)
 , Keccak512(..)
 
--- *** Unsafe finalize functions
-, finalizeKeccak256Ptr
-, finalizeKeccak512Ptr
-
 -- ** Blake2
 --
 -- $blake2
@@ -101,6 +104,7 @@ module Data.Hash.Internal.OpenSSL
 import Control.Exception
 import Control.Monad
 
+import Data.Array.Byte
 import Data.ByteString.Short qualified as BS
 import Data.Typeable
 import Data.Void
@@ -176,6 +180,12 @@ nullConstPtr :: ConstPtr a
 nullConstPtr = ConstPtr nullPtr
 
 -- -------------------------------------------------------------------------- --
+-- Misc utils
+
+toCSize# :: Int# -> CSize
+toCSize# i# = fromIntegral (I# i#)
+
+-- -------------------------------------------------------------------------- --
 -- OpenSSL Message Digest Algorithms
 
 -- | An algorithm implementation from an OpenSSL algorithm provider.
@@ -186,7 +196,7 @@ nullConstPtr = ConstPtr nullPtr
 --
 -- It is assumed that this always points to a valid algorithm implementation.
 --
-newtype Algorithm a = Algorithm (ForeignPtr Void)
+newtype Algorithm a = Algorithm (ForeignPtr a)
 
 instance Typeable a => Show (Algorithm a) where
     show _ = show (typeRep (Nothing @a))
@@ -194,6 +204,9 @@ instance Typeable a => Show (Algorithm a) where
 class KnownNat (OpenSslDigestSize a) => OpenSslDigest a where
     type OpenSslDigestSize a :: Natural
     algorithm :: Algorithm a
+
+openSslDigestSize :: forall a n . OpenSslDigest a => Num n => n
+openSslDigestSize = fromIntegral $ natVal' @(OpenSslDigestSize a) proxy#
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 -- | Fetches the digest implementation for the given algorithm from any provider
@@ -255,7 +268,7 @@ fetchAlgorithm name = do
 -- This can be used with @DerivingVia@ to derive hash instances for concrete
 -- message digest algorithms.
 --
-newtype Digest a = Digest BS.ShortByteString
+newtype Digest a = Digest ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
 
@@ -279,20 +292,16 @@ foreign import ccall unsafe "openssl/evp.h EVP_DigestInit_ex"
     c_evp_digest_init :: Ptr ctx -> ConstPtr alg -> Ptr Void {- nullPtr -} -> IO CInt
 
 foreign import ccall unsafe "openssl/evp.h EVP_DigestUpdate"
-    c_evp_digest_update :: Ptr ctx -> ConstPtr d -> CSize -> IO CInt
+    c_evp_digest_update_ptr :: Ptr ctx -> ConstPtr d -> CSize -> IO CInt
 
-foreign import ccall unsafe "openssl/evp.h EVP_DigestUpdate"
-    c_evp_digest_update_ba :: Ptr ctx -> ByteArray# -> CSize -> IO CInt
+foreign import capi unsafe "evp_wrapper.h EVP_DigestUpdate_off"
+    c_evp_digest_update_off :: Ptr ctx -> ByteArray# -> CSize -> CSize -> IO CInt
 
 foreign import ccall unsafe "openssl/evp.h EVP_DigestFinal_ex"
-    c_evp_digest_final :: Ptr ctx -> MutableByteArray# s -> Ptr CUInt -> IO CInt
+    c_evp_digest_final_ptr :: Ptr ctx -> Ptr CUChar -> Ptr CUInt -> IO CInt
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-foreign import ccall unsafe "openssl/evp.h EVP_MD_CTX_get0_md"
-#else
-foreign import ccall unsafe "openssl/evp.h EVP_MD_CTX_md"
-#endif
-    c_evp_md_ctx_get0_md :: ConstPtr ctx -> ConstPtr a
+foreign import capi unsafe "evp_wrapper.h EVP_DigestFinal_ex_off"
+    c_evp_digest_final_off :: Ptr ctx -> MutableByteArray# RealWorld -> CSize -> Ptr CUInt -> IO CInt
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 foreign import ccall unsafe "openssl/evp.h EVP_MD_get_size"
@@ -301,7 +310,23 @@ foreign import ccall unsafe "openssl/evp.h EVP_MD_size"
 #endif
     c_evp_md_get_size :: ConstPtr a -> CInt
 
-newCtx :: IO (Ctx a)
+-- | Assert the correct output size for the context.
+--
+-- NOTE that for OpenSSL <3.4 the output for XOF digests is size that
+-- corresponds to the security of the algorithm.
+--
+-- Starting with OpenSSL 3.4 the output for XOF digests is 0.
+--
+assertAlgorithmDigestSize :: forall a . OpenSslDigest a => (Ptr a) -> IO ()
+assertAlgorithmDigestSize algPtr =
+    unless (mdSize == 0 || mdSize == algSize) $ throw $ OpenSslException $
+        "failed to create new context for output size " <> show algSize
+            <> ". The algorithm offers " <> show mdSize
+  where
+    mdSize = fromIntegral @_ @Int $ c_evp_md_get_size (ConstPtr algPtr)
+    algSize = openSslDigestSize @a
+
+newCtx :: forall a . IO (Ctx a)
 newCtx = mask_ $ do
     ptr <- c_evp_ctx_new
     when (ptr == nullPtr) $ throw $ OpenSslException "failed to create new context"
@@ -311,11 +336,12 @@ newCtx = mask_ $ do
 -- | Allocates and initializes a new context. The context may be reused by
 -- calling 'resetCtx' on it.
 --
-initCtx :: Algorithm a -> IO (Ctx a)
+initCtx :: forall a . OpenSslDigest a => Algorithm a -> IO (Ctx a)
 initCtx (Algorithm alg) = do
     c@(Ctx ctx) <- newCtx
     r <- withForeignPtr ctx $ \ctxPtr ->
-        withForeignPtr alg $ \algPtr ->
+        withForeignPtr alg $ \algPtr -> do
+            assertAlgorithmDigestSize algPtr
             c_evp_digest_init ctxPtr (ConstPtr algPtr) nullPtr
     when (r == 0) $ throw $ OpenSslException "digest initialization failed"
     return c
@@ -332,37 +358,53 @@ resetCtx (Ctx ctx) = do
 
 -- | Feed more data into an context.
 --
-updateCtx :: Ctx a -> Ptr Word8 -> Int -> IO ()
-updateCtx (Ctx ctx) d c = withForeignPtr ctx $ \ptr -> do
-    r <- c_evp_digest_update ptr (ConstPtr d) (fromIntegral c)
+updateCtxPtr :: Ctx a -> Ptr Word8 -> Int -> IO ()
+updateCtxPtr (Ctx ctx) d c = withForeignPtr ctx $ \ptr -> do
+    r <- c_evp_digest_update_ptr ptr (ConstPtr d) (fromIntegral c)
     when (r == 0) $ throw $ OpenSslException "digest update failed"
-{-# INLINE updateCtx #-}
+{-# INLINE updateCtxPtr #-}
 
 -- | Feed more data into an context from an possibly unpinned ByteArray without
 -- copying the content.
 --
-updateCtx# :: Ctx a -> ByteArray# -> IO ()
-updateCtx# (Ctx ctx) arr = withForeignPtr ctx $ \ptr -> do
-    let !c = I# $ sizeofByteArray# arr
-    r <- c_evp_digest_update_ba ptr arr (fromIntegral c)
+updateCtx# :: Ctx a -> ByteArray# -> Int# -> Int# -> IO ()
+updateCtx# (Ctx ctx) arr# off# len# = withForeignPtr ctx $ \ptr -> do
+    when (isTrue# (size# <# off# +# len#)) $
+        throwIO $ OpenSslException "input array to small"
+    r <- c_evp_digest_update_off ptr arr# (toCSize# off#) (toCSize# len#)
     when (r == 0) $ throw $ OpenSslException "digest update failed"
+  where
+    size# = sizeofByteArray# arr#
 {-# INLINE updateCtx# #-}
 
 -- | Finalize a hash and return the digest.
 --
-finalCtx :: Ctx a -> IO (Digest a)
-finalCtx (Ctx ctx) = withForeignPtr ctx $ \ptr -> do
-    let !(I# size) = fromIntegral $ c_evp_md_get_size (c_evp_md_ctx_get0_md (ConstPtr ptr))
-    r <- IO $ \s ->
-        case newByteArray# size s of
-            (# s1, marr #) -> case unIO (c_evp_digest_final ptr marr nullPtr) s1 of
-                (# s2, 0 #) -> (# s2, Nothing #)
-                (# s3, _ #) -> case unsafeFreezeByteArray# marr s3 of
-                    (# s4, arr #) -> (# s4, Just (BS.SBS arr) #)
-    case r of
-        Nothing -> throwIO $ OpenSslException "digest finalization failed"
-        Just a -> return $ Digest a
-{-# INLINE finalCtx #-}
+finalCtx#
+    :: forall a
+    . OpenSslDigest a
+    => Ctx a
+    -> MutableByteArray# RealWorld
+    -> Int#
+    -> IO ()
+finalCtx# (Ctx ctx) arr# off# = withForeignPtr ctx $ \ptr -> do
+
+    -- When this is called from the default implementation of final this check
+    -- is redundant. But I guess it is cheap enough to worry about it.
+    asize <- IO $ \s -> case getSizeofMutableByteArray# arr# s of
+            (# s', n# #) -> (# s', I# (n# -# off#) #)
+    when (asize < openSslDigestSize @a) $
+        throwIO $ OpenSslException "array to small for digest"
+
+    r <- c_evp_digest_final_off ptr arr# (toCSize# off#) nullPtr
+    when (r == 0) $ throwIO $ OpenSslException "digest finalization failed"
+{-# INLINE finalCtx# #-}
+
+finalCtxPtr :: Ctx a -> Ptr Word8 -> IO ()
+finalCtxPtr (Ctx ctx) dptr =
+    withForeignPtr ctx $ \cptr -> do
+        r <- c_evp_digest_final_ptr cptr (castPtr dptr) nullPtr
+        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
+{-# INLINE finalCtxPtr #-}
 
 -- -------------------------------------------------------------------------- --
 -- Hash Instances for Digest
@@ -371,14 +413,15 @@ instance OpenSslDigest a => Hash (Digest a) where
     initialize = initCtx (algorithm @a)
     {-# INLINE initialize #-}
 
-instance OpenSslDigest a => IncrementalHash (Digest a) where
+instance (OpenSslDigest a) => IncrementalHash (Digest a) where
     type Context (Digest a) = Ctx a
     type DigestSize (Digest a) = OpenSslDigestSize a
-    updatePtr = updateCtx
+    updatePtr = updateCtxPtr
     update# = updateCtx#
-    finalize = finalCtx
+    finalize# = finalCtx#
+    finalizePtr = finalCtxPtr
     {-# INLINE updatePtr #-}
-    {-# INLINE finalize #-}
+    {-# INLINE finalize# #-}
 
 instance OpenSslDigest a => ResetableHash (Digest a) where
     reset = resetCtx
@@ -387,48 +430,89 @@ instance OpenSslDigest a => ResetableHash (Digest a) where
 -- -------------------------------------------------------------------------- --
 -- Hashes based on extendable-output functions (XOF)
 
-newtype XOF_Digest (n :: Natural) a = XOF_Digest BS.ShortByteString
+newtype XOF_Digest a = XOF_Digest ByteArray
     deriving (Eq, Ord)
-    deriving (Hash, ResetableHash) via (Digest a)
+    deriving (ResetableHash) via (Digest a)
     deriving (Show, IsString) via B16ShortByteString
 
--- foreign import ccall unsafe "openssl/evp.h EVP_DigestFinalXOF"
---     c_EVP_DigestFinalXOF :: Ptr ctx -> Ptr CUChar -> CSize -> IO CInt
+#if OPENSSL_VERSION_NUMBER < 0x30400000L
+-- | For OpenSSL <3.4 this implementation skips the assertion of the output
+-- digest size for XOF digests.
+--
+instance OpenSslDigest a => Hash (XOF_Digest a) where
+    initialize = xof_initCtx (algorithm @a)
+    {-# INLINE initialize #-}
+
+-- | Allocates and initializes a new context. The context may be reused by
+-- calling 'resetCtx' on it.
+--
+-- This is the same as 'initCtx' but omits the assertion of the output digest
+-- size.
+--
+xof_initCtx :: forall a . OpenSslDigest a => Algorithm a -> IO (Ctx a)
+xof_initCtx (Algorithm alg) = do
+    c@(Ctx ctx) <- newCtx
+    r <- withForeignPtr ctx $ \ctxPtr ->
+        withForeignPtr alg $ \algPtr -> do
+            c_evp_digest_init ctxPtr (ConstPtr algPtr) nullPtr
+    when (r == 0) $ throw $ OpenSslException "digest initialization failed"
+    return c
+{-# INLINE xof_initCtx #-}
+#else
+deriving via (Digest a) instance OpenSslDigest a => Hash (XOF_Digest a)
+#endif
 
 foreign import ccall unsafe "openssl/evp.h EVP_DigestFinalXOF"
-    c_EVP_DigestFinalXOF :: Ptr ctx -> MutableByteArray# s -> CSize -> IO CInt
+    c_EVP_DigestFinalXOF_ptr :: Ptr ctx -> Ptr CUChar -> CSize -> IO CInt
+
+foreign import capi unsafe "evp_wrapper.h EVP_DigestFinalXOF_off"
+    c_EVP_DigestFinalXOF_off :: Ptr ctx -> MutableByteArray# s -> CSize -> CSize -> IO CInt
 
 -- | Finalize an XOF based hash and return the digest.
 --
-xof_finalCtx :: forall n a . KnownNat n => Ctx a -> IO (XOF_Digest n a)
-xof_finalCtx (Ctx ctx) = withForeignPtr ctx $ \ptr -> do
-    r <- IO $ \s ->
-        case newByteArray# size# s of
-            (# s1, marr #) -> case unIO (c_EVP_DigestFinalXOF ptr marr (fromIntegral size)) s1 of
-                (# s2, 0 #) -> (# s2, Nothing #)
-                (# s3, _ #) -> case unsafeFreezeByteArray# marr s3 of
-                    (# s4, arr #) -> (# s4, Just (BS.SBS arr) #)
-    case r of
-        Nothing -> throwIO $ OpenSslException "digest finalization failed"
-        Just a -> return $ XOF_Digest a
-  where
-    !size@(I# size#) = fromIntegral $ natVal' @n proxy#
-{-# INLINE xof_finalCtx #-}
+xof_finalCtx#
+    :: forall a
+    . OpenSslDigest a
+    => Ctx a
+    -> MutableByteArray# RealWorld
+    -> Int#
+    -> IO ()
+xof_finalCtx# (Ctx ctx) arr# off# = withForeignPtr ctx $ \ptr -> do
 
-instance KnownNat n => IncrementalHash (XOF_Digest n a) where
-    type Context (XOF_Digest n a) = Ctx a
-    type DigestSize (XOF_Digest n a) = n
-    updatePtr = updateCtx
+    -- When this is called from the default implementation of final this check
+    -- is redundant. But I guess it is cheap enough to worry about it.
+    asize <- IO $ \s -> case getSizeofMutableByteArray# arr# s of
+            (# s', n# #) -> (# s', I# (n# -# off#) #)
+    when (asize < openSslDigestSize @a) $
+        throwIO $ OpenSslException "array to small for digest"
+
+    r <- c_EVP_DigestFinalXOF_off ptr arr# (toCSize# off#) (openSslDigestSize @a)
+    when (r == 0) $ throwIO $ OpenSslException "digest finalization failed"
+{-# INLINE xof_finalCtx# #-}
+
+xof_finalCtxPtr :: forall a . OpenSslDigest a => Ctx a -> Ptr Word8 -> IO ()
+xof_finalCtxPtr (Ctx ctx) dptr =
+    withForeignPtr ctx $ \cptr -> do
+        r <- c_EVP_DigestFinalXOF_ptr cptr (castPtr dptr) (openSslDigestSize @a)
+        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
+{-# INLINE xof_finalCtxPtr #-}
+
+instance OpenSslDigest a => IncrementalHash (XOF_Digest a) where
+    type Context (XOF_Digest a) = Ctx a
+    type DigestSize (XOF_Digest a) = OpenSslDigestSize a
+    updatePtr = updateCtxPtr
     update# = updateCtx#
-    finalize = xof_finalCtx
+    finalize# = xof_finalCtx#
+    finalizePtr = xof_finalCtxPtr
     {-# INLINE updatePtr #-}
-    {-# INLINE finalize #-}
+    {-# INLINE finalize# #-}
+    {-# INLINE finalizePtr #-}
 
 #if OPENSSL_VERSION_NUMBER < 0x30200000L
 -- -------------------------------------------------------------------------- --
 -- Legacy Keccak Implementation
 
-newtype LegacyKeccak_Digest a = LegacyKeccak_Digest BS.ShortByteString
+newtype LegacyKeccak_Digest a = LegacyKeccak_Digest ByteArray
     deriving (Eq, Ord)
     deriving (IncrementalHash) via (Digest a)
     deriving (Show, IsString) via B16ShortByteString
@@ -457,7 +541,7 @@ instance OpenSslDigest a => Hash (LegacyKeccak_Digest a) where
     initialize = legacyKeccak_initCtx (algorithm @a)
     {-# INLINE initialize #-}
 
-instance ResetableHash (LegacyKeccak_Digest a) where
+instance OpenSslDigest a => ResetableHash (LegacyKeccak_Digest a) where
     reset = legacyKeccak_resetCtx
     {-# INLINE reset #-}
 #endif
@@ -508,7 +592,7 @@ sha2_512_256 :: Algorithm Sha2_512_256
 sha2_512_256 = unsafePerformIO $ fetchAlgorithm "SHA512-256"
 {-# NOINLINE sha2_512_256 #-}
 
-newtype Sha2_224 = Sha2_224 BS.ShortByteString
+newtype Sha2_224 = Sha2_224 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_224)
@@ -516,7 +600,7 @@ instance OpenSslDigest Sha2_224 where
     type OpenSslDigestSize Sha2_224 = 28
     algorithm = sha2_224
 
-newtype Sha2_256 = Sha2_256 BS.ShortByteString
+newtype Sha2_256 = Sha2_256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_256)
@@ -524,7 +608,7 @@ instance OpenSslDigest Sha2_256 where
     type OpenSslDigestSize Sha2_256 = 32
     algorithm = sha2_256
 
-newtype Sha2_384 = Sha2_384 BS.ShortByteString
+newtype Sha2_384 = Sha2_384 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_384)
@@ -532,7 +616,7 @@ instance OpenSslDigest Sha2_384 where
     type OpenSslDigestSize Sha2_384 = 48
     algorithm = sha2_384
 
-newtype Sha2_512 = Sha2_512 BS.ShortByteString
+newtype Sha2_512 = Sha2_512 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512)
@@ -540,7 +624,7 @@ instance OpenSslDigest Sha2_512 where
     type OpenSslDigestSize Sha2_512 = 64
     algorithm = sha2_512
 
-newtype Sha2_512_224 = Sha2_512_224 BS.ShortByteString
+newtype Sha2_512_224 = Sha2_512_224 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512_224)
@@ -548,7 +632,7 @@ instance OpenSslDigest Sha2_512_224 where
     type OpenSslDigestSize Sha2_512_224 = 28
     algorithm = sha2_512_224
 
-newtype Sha2_512_256 = Sha2_512_256 BS.ShortByteString
+newtype Sha2_512_256 = Sha2_512_256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha2_512_256)
@@ -594,7 +678,7 @@ shake256 :: Algorithm (Shake256 n)
 shake256 = unsafePerformIO $ fetchAlgorithm "SHAKE256"
 {-# NOINLINE shake256 #-}
 
-newtype Sha3_224 = Sha3_224 BS.ShortByteString
+newtype Sha3_224 = Sha3_224 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_224)
@@ -602,7 +686,7 @@ instance OpenSslDigest Sha3_224 where
     type OpenSslDigestSize Sha3_224 = 28
     algorithm = sha3_224
 
-newtype Sha3_256 = Sha3_256 BS.ShortByteString
+newtype Sha3_256 = Sha3_256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_256)
@@ -610,7 +694,7 @@ instance OpenSslDigest Sha3_256 where
     type OpenSslDigestSize Sha3_256 = 32
     algorithm = sha3_256
 
-newtype Sha3_384 = Sha3_384 BS.ShortByteString
+newtype Sha3_384 = Sha3_384 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_384)
@@ -618,7 +702,7 @@ instance OpenSslDigest Sha3_384 where
     type OpenSslDigestSize Sha3_384 = 48
     algorithm = sha3_384
 
-newtype Sha3_512 = Sha3_512 BS.ShortByteString
+newtype Sha3_512 = Sha3_512 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (Digest Sha3_512)
@@ -626,18 +710,18 @@ instance OpenSslDigest Sha3_512 where
     type OpenSslDigestSize Sha3_512 = 64
     algorithm = sha3_512
 
-newtype Shake128 (bits :: Natural) = Shake128 BS.ShortByteString
+newtype Shake128 (n :: Natural) = Shake128 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
-    deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest bits (Shake128 bits))
+    deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest (Shake128 n))
 instance KnownNat n => OpenSslDigest (Shake128 n) where
     type OpenSslDigestSize (Shake128 n) = n
     algorithm = shake128
 
-newtype Shake256 (bits :: Natural) = Shake256 BS.ShortByteString
+newtype Shake256 (n :: Natural) = Shake256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
-    deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest bits (Shake256 bits))
+    deriving (IncrementalHash, Hash, ResetableHash) via (XOF_Digest (Shake256 n))
 instance KnownNat n => OpenSslDigest (Shake256 n) where
     type OpenSslDigestSize (Shake256 n) = n
     algorithm = shake256
@@ -699,7 +783,7 @@ keccak_512 :: Algorithm Keccak512
 keccak_512 = unsafePerformIO $ fetchAlgorithm KECCAK(512)
 {-# NOINLINE keccak_512 #-}
 
-newtype Keccak224 = Keccak224 BS.ShortByteString
+newtype Keccak224 = Keccak224 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak224)
@@ -707,7 +791,7 @@ instance OpenSslDigest Keccak224 where
     type OpenSslDigestSize Keccak224 = 28
     algorithm = keccak_224
 
-newtype Keccak256 = Keccak256 BS.ShortByteString
+newtype Keccak256 = Keccak256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak256)
@@ -715,7 +799,7 @@ instance OpenSslDigest Keccak256 where
     type OpenSslDigestSize Keccak256 = 32
     algorithm = keccak_256
 
-newtype Keccak384 = Keccak384 BS.ShortByteString
+newtype Keccak384 = Keccak384 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak384)
@@ -723,40 +807,13 @@ instance OpenSslDigest Keccak384 where
     type OpenSslDigestSize Keccak384 = 48
     algorithm = keccak_384
 
-newtype Keccak512 = Keccak512 BS.ShortByteString
+newtype Keccak512 = Keccak512 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
     deriving (IncrementalHash, Hash, ResetableHash) via (KECCAK_DIGEST Keccak512)
 instance OpenSslDigest Keccak512 where
     type OpenSslDigestSize Keccak512 = 64
     algorithm = keccak_512
-
--- | Low-Level function that writes the final digest directly into the provided
--- pointer. The pointer must point to at least 64 bytes of allocated memory.
--- This is not checked and a violation of this condition may result in a
--- segmentation fault.
---
-finalizeKeccak256Ptr :: Ctx Keccak256 -> Ptr Word8 -> IO ()
-finalizeKeccak256Ptr (Ctx ctx) dptr =
-    withForeignPtr ctx $ \cptr -> do
-        r <- c_evp_digest_final_ptr cptr (castPtr dptr) nullPtr
-        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
-{-# INLINE finalizeKeccak256Ptr #-}
-
--- | Low-Level function that writes the final digest directly into the provided
--- pointer. The pointer must point to at least 64 bytes of allocated memory.
--- This is not checked and a violation of this condition may result in a
--- segmentation fault.
---
-finalizeKeccak512Ptr :: Ctx Keccak512 -> Ptr Word8 -> IO ()
-finalizeKeccak512Ptr (Ctx ctx) dptr = do
-    withForeignPtr ctx $ \cptr -> do
-        r <- c_evp_digest_final_ptr cptr (castPtr dptr) nullPtr
-        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
-{-# INLINE finalizeKeccak512Ptr #-}
-
-foreign import ccall unsafe "openssl/evp.h EVP_DigestFinal_ex"
-    c_evp_digest_final_ptr :: Ptr ctx -> Ptr CUChar -> Ptr CUInt -> IO CInt
 
 -- -------------------------------------------------------------------------- --
 -- Blake
@@ -785,18 +842,18 @@ blake2s256 :: Algorithm Blake2s256
 blake2s256 = unsafePerformIO $ fetchAlgorithm "BLAKE2s256"
 {-# NOINLINE blake2s256 #-}
 
-newtype Blake2b512 = Blake2b512 BS.ShortByteString
+newtype Blake2b512 = Blake2b512 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
-    deriving (IncrementalHash, Hash) via (Digest Blake2b512)
+    deriving (IncrementalHash, Hash, ResetableHash) via (Digest Blake2b512)
 instance OpenSslDigest Blake2b512 where
     type OpenSslDigestSize Blake2b512 = 64
     algorithm = blake2b512
 
-newtype Blake2s256 = Blake2s256 BS.ShortByteString
+newtype Blake2s256 = Blake2s256 ByteArray
     deriving (Eq, Ord)
     deriving (Show, IsString) via B16ShortByteString
-    deriving (IncrementalHash, Hash) via (Digest Blake2s256)
+    deriving (IncrementalHash, Hash, ResetableHash) via (Digest Blake2s256)
 instance OpenSslDigest Blake2s256 where
     type OpenSslDigestSize Blake2s256 = 32
     algorithm = blake2s256

--- a/src/Data/Hash/Internal/OpenSSL.hs
+++ b/src/Data/Hash/Internal/OpenSSL.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -11,7 +12,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UnliftedFFITypes #-}
 
 #if !MIN_VERSION_base(4,18,0)
 {-# LANGUAGE PatternSynonyms #-}
@@ -110,7 +113,6 @@ import Foreign.C.String(CString, withCString)
 #endif
 import Foreign.C.Types
 import Foreign.ForeignPtr
-import Foreign.Marshal
 import Foreign.Ptr
 
 import GHC.Exts
@@ -277,8 +279,11 @@ foreign import ccall unsafe "openssl/evp.h EVP_DigestInit_ex"
 foreign import ccall unsafe "openssl/evp.h EVP_DigestUpdate"
     c_evp_digest_update :: Ptr ctx -> ConstPtr d -> CSize -> IO CInt
 
+foreign import ccall unsafe "openssl/evp.h EVP_DigestUpdate"
+    c_evp_digest_update_ba :: Ptr ctx -> ByteArray# -> CSize -> IO CInt
+
 foreign import ccall unsafe "openssl/evp.h EVP_DigestFinal_ex"
-    c_evp_digest_final :: Ptr ctx -> Ptr CUChar -> Ptr CUInt -> IO CInt
+    c_evp_digest_final :: Ptr ctx -> MutableByteArray# s -> Ptr CUInt -> IO CInt
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 foreign import ccall unsafe "openssl/evp.h EVP_MD_CTX_get0_md"
@@ -331,15 +336,30 @@ updateCtx (Ctx ctx) d c = withForeignPtr ctx $ \ptr -> do
     when (r == 0) $ throw $ OpenSslException "digest update failed"
 {-# INLINE updateCtx #-}
 
+-- | Feed more data into an context from an possibly unpinned ByteArray without
+-- copying the content.
+--
+updateCtx# :: Ctx a -> ByteArray# -> IO ()
+updateCtx# (Ctx ctx) arr = withForeignPtr ctx $ \ptr -> do
+    let !c = I# $ sizeofByteArray# arr
+    r <- c_evp_digest_update_ba ptr arr (fromIntegral c)
+    when (r == 0) $ throw $ OpenSslException "digest update failed"
+{-# INLINE updateCtx# #-}
+
 -- | Finalize a hash and return the digest.
 --
 finalCtx :: Ctx a -> IO (Digest a)
 finalCtx (Ctx ctx) = withForeignPtr ctx $ \ptr -> do
-    let s = fromIntegral $ c_evp_md_get_size (c_evp_md_ctx_get0_md (ConstPtr ptr))
-    allocaBytes s $ \dptr -> do
-        r <- c_evp_digest_final ptr dptr nullPtr
-        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
-        Digest <$> BS.packCStringLen (castPtr dptr, s)
+    let !(I# size) = fromIntegral $ c_evp_md_get_size (c_evp_md_ctx_get0_md (ConstPtr ptr))
+    r <- IO $ \s ->
+        case newByteArray# size s of
+            (# s1, marr #) -> case unIO (c_evp_digest_final ptr marr nullPtr) s1 of
+                (# s2, 0 #) -> (# s2, Nothing #)
+                (# s3, _ #) -> case unsafeFreezeByteArray# marr s3 of
+                    (# s4, arr #) -> (# s4, Just (BS.SBS arr) #)
+    case r of
+        Nothing -> throwIO $ OpenSslException "digest finalization failed"
+        Just a -> return $ Digest a
 {-# INLINE finalCtx #-}
 
 -- -------------------------------------------------------------------------- --
@@ -351,9 +371,10 @@ instance OpenSslDigest a => Hash (Digest a) where
 
 instance IncrementalHash (Digest a) where
     type Context (Digest a) = Ctx a
-    update = updateCtx
+    updatePtr = updateCtx
+    update# = updateCtx#
     finalize = finalCtx
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance ResetableHash (Digest a) where
@@ -368,26 +389,35 @@ newtype XOF_Digest (n :: Natural) a = XOF_Digest BS.ShortByteString
     deriving (Hash, ResetableHash) via (Digest a)
     deriving (Show, IsString) via B16ShortByteString
 
+-- foreign import ccall unsafe "openssl/evp.h EVP_DigestFinalXOF"
+--     c_EVP_DigestFinalXOF :: Ptr ctx -> Ptr CUChar -> CSize -> IO CInt
+
 foreign import ccall unsafe "openssl/evp.h EVP_DigestFinalXOF"
-    c_EVP_DigestFinalXOF :: Ptr ctx -> Ptr CUChar -> CSize -> IO CInt
+    c_EVP_DigestFinalXOF :: Ptr ctx -> MutableByteArray# s -> CSize -> IO CInt
 
 -- | Finalize an XOF based hash and return the digest.
 --
 xof_finalCtx :: forall n a . KnownNat n => Ctx a -> IO (XOF_Digest n a)
 xof_finalCtx (Ctx ctx) = withForeignPtr ctx $ \ptr -> do
-    allocaBytes s $ \dptr -> do
-        r <- c_EVP_DigestFinalXOF ptr dptr (fromIntegral s)
-        when (r == 0) $ throw $ OpenSslException "digest finalization failed"
-        XOF_Digest <$> BS.packCStringLen (castPtr dptr, s)
+    r <- IO $ \s ->
+        case newByteArray# size# s of
+            (# s1, marr #) -> case unIO (c_EVP_DigestFinalXOF ptr marr (fromIntegral size)) s1 of
+                (# s2, 0 #) -> (# s2, Nothing #)
+                (# s3, _ #) -> case unsafeFreezeByteArray# marr s3 of
+                    (# s4, arr #) -> (# s4, Just (BS.SBS arr) #)
+    case r of
+        Nothing -> throwIO $ OpenSslException "digest finalization failed"
+        Just a -> return $ XOF_Digest a
   where
-    s = fromIntegral $ natVal' @n proxy#
+    !size@(I# size#) = fromIntegral $ natVal' @n proxy#
 {-# INLINE xof_finalCtx #-}
 
 instance KnownNat n => IncrementalHash (XOF_Digest n a) where
     type Context (XOF_Digest n a) = Ctx a
-    update = updateCtx
+    updatePtr = updateCtx
+    update# = updateCtx#
     finalize = xof_finalCtx
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 #if OPENSSL_VERSION_NUMBER < 0x30200000L
@@ -673,7 +703,7 @@ instance OpenSslDigest Keccak512 where algorithm = keccak_512
 finalizeKeccak256Ptr :: Ctx Keccak256 -> Ptr Word8 -> IO ()
 finalizeKeccak256Ptr (Ctx ctx) dptr =
     withForeignPtr ctx $ \cptr -> do
-        r <- c_evp_digest_final cptr (castPtr dptr) nullPtr
+        r <- c_evp_digest_final_ptr cptr (castPtr dptr) nullPtr
         when (r == 0) $ throw $ OpenSslException "digest finalization failed"
 {-# INLINE finalizeKeccak256Ptr #-}
 
@@ -685,9 +715,12 @@ finalizeKeccak256Ptr (Ctx ctx) dptr =
 finalizeKeccak512Ptr :: Ctx Keccak512 -> Ptr Word8 -> IO ()
 finalizeKeccak512Ptr (Ctx ctx) dptr = do
     withForeignPtr ctx $ \cptr -> do
-        r <- c_evp_digest_final cptr (castPtr dptr) nullPtr
+        r <- c_evp_digest_final_ptr cptr (castPtr dptr) nullPtr
         when (r == 0) $ throw $ OpenSslException "digest finalization failed"
 {-# INLINE finalizeKeccak512Ptr #-}
+
+foreign import ccall unsafe "openssl/evp.h EVP_DigestFinal_ex"
+    c_evp_digest_final_ptr :: Ptr ctx -> Ptr CUChar -> Ptr CUInt -> IO CInt
 
 -- -------------------------------------------------------------------------- --
 -- Blake

--- a/src/Data/Hash/Keccak.hs
+++ b/src/Data/Hash/Keccak.hs
@@ -33,11 +33,7 @@ module Data.Hash.Keccak
   Keccak256(..)
 , Keccak512(..)
 , module Data.Hash.Class.Mutable
-
--- *** Unsafe finalize functions
-, finalizeKeccak256Ptr
-, finalizeKeccak512Ptr
-
+, OpenSslException(..)
 ) where
 
 import Data.Hash.Class.Mutable

--- a/src/Data/Hash/SHA2.hs
+++ b/src/Data/Hash/SHA2.hs
@@ -23,6 +23,7 @@ module Data.Hash.SHA2
 , Sha2_512_256(..)
 
 , module Data.Hash.Class.Mutable
+, OpenSslException(..)
 ) where
 
 import Data.Hash.Class.Mutable

--- a/src/Data/Hash/SHA3.hs
+++ b/src/Data/Hash/SHA3.hs
@@ -27,6 +27,7 @@ module Data.Hash.SHA3
 , type Shake256_512
 
 , module Data.Hash.Class.Mutable
+, OpenSslException(..)
 ) where
 
 import Data.Hash.Class.Mutable

--- a/src/Data/Hash/SipHash.hs
+++ b/src/Data/Hash/SipHash.hs
@@ -121,10 +121,11 @@ sipHash48 = sipHashCD
 
 instance (SipHashParam c, SipHashParam d) => IncrementalHash (SipHash c d) where
     type Context (SipHash c d) = SipHashContext c d
-    update = sipHashUpdate
+    type DigestSize (SipHash c d) = 8
+    updatePtr = sipHashUpdate
     finalize = sipHashFinalize
 
-    {-# INLINE update #-}
+    {-# INLINE updatePtr #-}
     {-# INLINE finalize #-}
 
 instance (SipHashParam c, SipHashParam d) => Hash (SipHash c d) where

--- a/test/Test/Data/Hash/Class/Pure.hs
+++ b/test/Test/Data/Hash/Class/Pure.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -20,10 +22,10 @@ module Test.Data.Hash.Class.Pure
 ) where
 
 import Data.Bits
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Short as BS
-import qualified Data.ByteString.Unsafe as B
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
+import Data.ByteString.Short qualified as BS
+import Data.ByteString.Unsafe qualified as B
 
 import Foreign.Marshal
 import Foreign.Ptr
@@ -75,7 +77,8 @@ newtype TestHash = TestHash { _getTestHash :: [Word8] }
 
 instance IncrementalHash TestHash where
     type Context TestHash = [Word8]
-    update ctx p l = (ctx ++) <$> peekArray l p
+    type DigestSize TestHash = 8
+    updatePtr ctx p l = (ctx ++) <$> peekArray l p
     finalize = TestHash
 
 instance Hash TestHash where
@@ -107,7 +110,7 @@ prop_hashByteArray bytes = unsafeDupablePerformIO $ IO $ \s0 ->
             case copyToArray 0# bytes a# s1 of
                 s2 -> case unsafeFreezeByteArray# a# s2 of
                     (# s3, b# #) ->
-                        let r = hashByteArray @TestHash () b# === TestHash bytes
+                        let r = hashByteArray# @TestHash () b# === TestHash bytes
                         in (# s3, r #)
   where
     !(I# size) = length bytes

--- a/test/Test/Data/Hash/Keccak.hs
+++ b/test/Test/Data/Hash/Keccak.hs
@@ -63,8 +63,9 @@ badExamples256 = describe "bad example hashes fail" $ do
 
 correctKeccakVersion :: Spec
 correctKeccakVersion = describe "correct Keccak version" $ do
-    it "is 32 bytes long" $
-        shouldBe (BS.length (coerce (hashByteString_ @Keccak256 ""))) 32
+    it "is 32 bytes long" $ do
+        shouldBe (digestSize @Keccak256) (32 :: Int)
+        shouldBe (BS.length (coerce (hashByteString_ @Keccak256 ""))) (digestSize @Keccak256)
     describe "Keccak256 is not SHA3" $ do
         failTest @Sha3_256 "" "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
         failTest @Sha3_256 "1234" "56570de287d73cd1cb6092bb8fdee6173974955fdef345ae579ee9f475ea7432"

--- a/test/Test/Data/Hash/SHA2.hs
+++ b/test/Test/Data/Hash/SHA2.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -24,9 +26,14 @@ module Test.Data.Hash.SHA2
 ( tests
 ) where
 
+import Control.Monad
+
 import Data.ByteString qualified as B
 import Data.ByteString.Short qualified as BS
 import Data.Coerce
+
+import GHC.Exts (Int#)
+import GHC.Int (Int(I#))
 
 import Test.Hspec
 import Test.Hash.SHA
@@ -39,10 +46,57 @@ import Data.Hash.SHA2
 --
 
 tests :: Spec
-tests = describe "SHA2 Test Vectors" $ do
-    shortMsgTests
-    longMsgTests
-    monteTests
+tests = do
+    describe "SHA2 misc tests" $ do
+        describe "offset tests" $ do
+            testOffsets
+            testOffsets2
+    describe "SHA2 Test Vectors" $ do
+        shortMsgTests
+        longMsgTests
+        monteTests
+
+-- -------------------------------------------------------------------------- --
+-- Miscelaneous Tests
+
+toI# :: Int -> Int#
+toI# !(I# i#) = i#
+
+testOffsets :: Spec
+testOffsets = do
+    it ("produces the same result on different offsets of a constant input") $ do
+        shouldReturn runAll True
+    it ("succeeds on empty input arrays") $ do
+        nullHash <- hashShortByteString @Sha2_256 ""
+        runEmpty <- run 10 0
+        shouldBe runEmpty nullHash
+  where
+    !(BS.SBS arr) = BS.replicate 1024 0x5f
+    run i l = do
+        ctx <- initialize @Sha2_256
+        update# @Sha2_256 ctx arr (toI# i) (toI# l)
+        finalize @Sha2_256 ctx
+    runAll = do
+        a <- run 0 35
+        foldM (\c i -> ((&&) c) . (== a) <$> run i 35) True [1..100]
+
+testOffsets2 :: Spec
+testOffsets2 = do
+    it ("produces the same result on different copies of the same data at different offsets") $
+        shouldReturn (runAll 0) True
+    it ("does not produce the same result on different copies of the same data at different offsets if offsets are wrong") $
+        shouldReturn (runAll 1) False
+    it ("fails if the input array is too small") $
+        shouldThrow (runAll 65) (const True :: Selector OpenSslException)
+  where
+    !(BS.SBS arr) = BS.pack $ concat $ replicate 5 [0..63]
+    run i x = do
+        ctx <- initialize @Sha2_256
+        update# @Sha2_256 ctx arr (toI# (i * 64 + x)) (toI# 64)
+        finalize @Sha2_256 ctx
+    runAll x = do
+        a <- run 0 0
+        foldM (\c i -> ((&&) c) . (== a) <$> run i x) True [0..3]
 
 -- -------------------------------------------------------------------------- --
 -- NIST Msg Tests

--- a/test/Test/Data/Hash/SHA2.hs
+++ b/test/Test/Data/Hash/SHA2.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -23,7 +24,8 @@ module Test.Data.Hash.SHA2
 ( tests
 ) where
 
-import qualified Data.ByteString.Short as BS
+import Data.ByteString qualified as B
+import Data.ByteString.Short qualified as BS
 import Data.Coerce
 
 import Test.Hspec
@@ -70,7 +72,7 @@ runMsgTest
     => MsgFile
     -> Spec
 runMsgTest = msgAssert
-    (\l a b -> it l (a == b))
+    (\l a b -> it l (a == b && B.length a == digestSize @a))
     (BS.fromShort . coerce . hashByteString_ @a)
 
 -- -------------------------------------------------------------------------- --
@@ -92,6 +94,6 @@ runMonteTest
     => MonteFile
     -> Spec
 runMonteTest = monteAssert
-    (\l a b -> it l (a == b))
+    (\l a b -> it l (a == b && B.length a == digestSize @a))
     (BS.fromShort . coerce . hashByteString_ @a)
 

--- a/test/Test/Data/Hash/SHA3.hs
+++ b/test/Test/Data/Hash/SHA3.hs
@@ -63,12 +63,17 @@ trivial = describe "trivial hashes" $ do
         => Eq a
         => Show a
         => Coercible a B16ShortByteString
+        => Coercible a BS.ShortByteString
         => String
         -> a
         -> Spec
     go l b = do
-        it l $ shouldBe (hashShortByteString_ @a "") b
-
+        it l $
+            shouldBe h b
+        it (l <> " digest size") $
+            shouldBe (BS.length $ coerce h) (digestSize @a)
+      where
+        h = hashShortByteString_ @a ""
 
 -- -------------------------------------------------------------------------- --
 -- Msg Tests


### PR DESCRIPTION
This branch contains a number of breaking changes for the API of mutable hashes.

* Add a low-level API and implementation for direct support of slices of unpinned memory.
* Include the static digest size into the API and implementation.